### PR TITLE
Lighten chat timestamp color

### DIFF
--- a/friendly-chat.html
+++ b/friendly-chat.html
@@ -131,7 +131,7 @@ body{font-family:'DM Sans',sans-serif;background:var(--bg);color:var(--text);hei
 .m-dot.twitch{background:var(--twitch);}
 .m-dot.youtube{background:var(--youtube);}
 .m-dot.kick{background:var(--kick);}
-.m-time{font-size:10px;font-family:'JetBrains Mono',monospace;color:var(--text-dim);flex-shrink:0;min-width:38px;}
+.m-time{font-size:10px;font-family:'JetBrains Mono',monospace;color:var(--text-muted);flex-shrink:0;min-width:38px;}
 .m-author{font-size:var(--chat-font-size);font-weight:500;flex-shrink:0;}
 .m-author.twitch{color:var(--twitch);}
 .m-author.youtube{color:var(--youtube);}


### PR DESCRIPTION
### Motivation
- Improve timestamp readability in the chat message feed by making the timestamp color lighter while preserving the existing visual hierarchy.

### Description
- Replace `color: var(--text-dim)` with `color: var(--text-muted)` for the `.m-time` CSS rule in `friendly-chat.html`.

### Testing
- No automated tests were run for this styling-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d024415d348321b503206286c854e0)