### PR TITLE
Fix Linux taskbar icon wiring

### DIFF
--- a/main.js
+++ b/main.js
@@ -43,6 +43,7 @@ function createWindow() {
   mainWindow = new BrowserWindow({
     width: 1280, height: 800, minWidth: 900, minHeight: 600,
     title: 'Friendly Chat',
+    icon: process.platform === 'linux' ? path.join(__dirname, 'icon.png') : undefined,
     webPreferences: {
       nodeIntegration: false,
       contextIsolation: true,

--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
       "preload.js",
       "server.js",
       "friendly-chat.html",
-      "config.json"
+      "config.json",
+      "icon.png"
     ],
     "win": {
       "target": "nsis",


### PR DESCRIPTION
### Motivation
- Linux desktop environments were falling back to the default Electron gear icon because the app did not set a runtime `BrowserWindow` icon for Linux and the `icon.png` asset was not guaranteed to be included in packaged builds.

### Description
- Set `icon: process.platform === 'linux' ? path.join(__dirname, 'icon.png') : undefined` in the `BrowserWindow` options in `main.js` so running app windows use the shipped `icon.png` on Linux.
- Added `icon.png` to the `build.files` list in `package.json` so the icon is present in packaged Linux builds and aligns with the existing `linux.icon` setting.

### Testing
- Verified `icon.png` is a 512×512 PNG by running a small Python header check script, which succeeded (`512 512 8 6`).
- Attempted to run `npm run build:linux -- --dir` to validate packaging but it failed due to a forbidden download of Electron binaries from GitHub releases in this environment, so packaging could not complete.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d0754a8dc8832195bf6c99a046ae53)