### PR TITLE
Add keepalive pings and auto-reconnect for Kick Pusher socket

### DIFF
--- a/friendly-chat.html
+++ b/friendly-chat.html
@@ -1214,9 +1214,14 @@ function connectTwitch(channel) {
   ws.onclose = () => { if(S.channels.twitch === channel) addSys('Twitch: disconnected'); };
 }
 
+const KICK_RECONNECT_BASE_DELAY_MS = 2000;
+const KICK_RECONNECT_MAX_DELAY_MS  = 30000;
+const KICK_MAX_RECONNECT_ATTEMPTS  = 10;
+
 // ---- Kick chat via Pusher WebSocket (anonymous read-only, no token needed) ----
-function connectKick(channel) {
+function connectKick(channel, reconnectAttempt = 0) {
   if(S.sockets.kick) { try{S.sockets.kick.close();}catch(e){} }
+  if(S.intervals.kick) { clearInterval(S.intervals.kick); S.intervals.kick = null; }
   addSys(`Connecting to Kick: ${channel}...`);
 
   // First fetch the channel info to get the chatroom ID
@@ -1239,6 +1244,7 @@ function connectKick(channel) {
       const PUSHER_KEY = '32cbd69e4b950bf97679';
       const ws = new WebSocket(`wss://ws-us2.pusher.com/app/${PUSHER_KEY}?protocol=7&client=js&version=7.4.0&flash=false`);
       S.sockets.kick = ws;
+      let forceClose = false;
 
       ws.onopen = () => {};
 
@@ -1251,8 +1257,20 @@ function connectKick(channel) {
             data: { auth: '', channel: `chatrooms.${chatroomId}.v2` }
           }));
           addSys(`Connected to Kick: ${channel}`);
+          reconnectAttempt = 0;
+          // Send a periodic client ping so idle rooms stay alive.
+          if(S.intervals.kick) clearInterval(S.intervals.kick);
+          S.intervals.kick = setInterval(() => {
+            if(S.channels.kick !== channel || S.sockets.kick !== ws || ws.readyState !== WebSocket.OPEN) return;
+            ws.send(JSON.stringify({ event: 'pusher:ping', data: {} }));
+          }, 4 * 60 * 1000);
           // Fetch recent chat history
           fetchKickHistory(chatroomId);
+          return;
+        }
+        // Required by Pusher protocol to keep the socket from timing out.
+        if(msg.event === 'pusher:ping') {
+          ws.send(JSON.stringify({ event: 'pusher:pong', data: {} }));
           return;
         }
         if(msg.event !== 'App\\Events\\ChatMessageEvent') return;
@@ -1291,7 +1309,28 @@ function connectKick(channel) {
       };
 
       ws.onerror = () => addSys('Kick: connection error');
-      ws.onclose = () => { if(S.channels.kick === channel) addSys('Kick: disconnected'); };
+      ws.onclose = () => {
+        if(S.intervals.kick) { clearInterval(S.intervals.kick); S.intervals.kick = null; }
+        if(S.sockets.kick === ws) S.sockets.kick = null;
+        if(S.channels.kick !== channel || forceClose) return;
+        addSys('Kick: disconnected');
+        if(reconnectAttempt >= KICK_MAX_RECONNECT_ATTEMPTS) {
+          addSys('Kick: reconnect limit reached (click Leave/Join to retry)');
+          return;
+        }
+        const delay = Math.min(KICK_RECONNECT_BASE_DELAY_MS * (2 ** reconnectAttempt), KICK_RECONNECT_MAX_DELAY_MS);
+        addSys(`Kick: reconnecting in ${Math.round(delay / 1000)}s...`);
+        setTimeout(() => {
+          if(S.channels.kick === channel) connectKick(channel, reconnectAttempt + 1);
+        }, delay);
+      };
+
+      // Prevent scheduled reconnect from firing when user manually leaves/switches.
+      const origClose = ws.close.bind(ws);
+      ws.close = (...args) => {
+        forceClose = true;
+        return origClose(...args);
+      };
     })
     .catch(err => addSys(`Kick: could not load channel (${err.message}). CORS may block this from file:// — use a local server.`));
 }


### PR DESCRIPTION
### Motivation
- Users observed Kick connections dropping after ~15 minutes, likely due to idle Pusher heartbeats and missing client keepalive and reconnect logic.

### Description
- Introduce reconnect configuration constants (`KICK_RECONNECT_BASE_DELAY_MS`, `KICK_RECONNECT_MAX_DELAY_MS`, `KICK_MAX_RECONNECT_ATTEMPTS`) and allow `connectKick` to accept a `reconnectAttempt` parameter.
- Clear any existing Kick keepalive interval on reconnect/close and set a periodic client ping every 4 minutes to reduce idle socket timeouts (`pusher:ping` -> send `pusher:pong`).
- Add handling for incoming `pusher:ping` messages and reply with `pusher:pong` to satisfy the Pusher heartbeat protocol.
- Implement exponential-backoff auto-reconnect with a capped number of attempts and avoid reconnects when the socket was intentionally closed by marking forced closes.

### Testing
- Validated the in-page script syntax by running `node -e "const fs=require('fs');const html=fs.readFileSync('friendly-chat.html','utf8');const m=html.match(/<script>([\s\S]*)<\/script>/);if(!m) throw new Error('script tag not found');new Function(m[1]);console.log('script syntax ok');"`, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d16fb4158c8321bd2e96379f5c04dd)