### PR TITLE
Fix YouTube auth expiring during long live chat sessions

### DIFF
--- a/friendly-chat.html
+++ b/friendly-chat.html
@@ -420,7 +420,8 @@ const S = {
   // Recent chatters for @mention autocomplete { "platform:name" -> { name, platform } }
   recentChatters: new Map(),
   youtubeSeenIds: new Set(),
-  youtubeReadMode: 'auto'
+  youtubeReadMode: 'auto',
+  youtubeRefreshPromise: null
 };
 
 // ALL_PLATFORMS must be defined before S.filter and S.target are initialized
@@ -429,6 +430,98 @@ S.filter = new Set(ALL_PLATFORMS);
 S.target = new Set(ALL_PLATFORMS);
 
 function ftime(){const d=new Date();return `${d.getHours().toString().padStart(2,'0')}:${d.getMinutes().toString().padStart(2,'0')}`;}
+
+function getRedirectUri() {
+  return window.location.origin + window.location.pathname;
+}
+
+function saveYouTubeTokens({ access_token, refresh_token, expires_in }) {
+  if(access_token) {
+    localStorage.setItem('youtube_access_token', access_token);
+    const ttlSeconds = Number(expires_in) || 3600;
+    localStorage.setItem('youtube_token_expiry', String(Date.now() + (ttlSeconds * 1000)));
+  }
+  if(refresh_token) {
+    localStorage.setItem('youtube_refresh_token', refresh_token);
+  }
+}
+
+async function exchangeYouTubeCodeForToken(code, codeVerifier) {
+  if(!code || !codeVerifier) throw new Error('Missing OAuth code verifier');
+  const payload = new URLSearchParams({
+    client_id: YOUTUBE_CLIENT_ID,
+    code,
+    code_verifier: codeVerifier,
+    grant_type: 'authorization_code',
+    redirect_uri: getRedirectUri()
+  });
+  const res = await fetch('https://oauth2.googleapis.com/token', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: payload.toString()
+  });
+  const data = await res.json().catch(() => ({}));
+  if(!res.ok || data.error) {
+    throw new Error(data.error_description || data.error || `HTTP ${res.status}`);
+  }
+  return data;
+}
+
+async function refreshYouTubeToken(force = false) {
+  if(S.youtubeRefreshPromise) return S.youtubeRefreshPromise;
+
+  const refreshToken = localStorage.getItem('youtube_refresh_token');
+  if(!refreshToken) return null;
+
+  const expiry = parseInt(localStorage.getItem('youtube_token_expiry') || '0', 10);
+  if(!force && S.tokens.youtube && expiry > Date.now() + 120000) {
+    return S.tokens.youtube;
+  }
+
+  S.youtubeRefreshPromise = (async () => {
+    const payload = new URLSearchParams({
+      client_id: YOUTUBE_CLIENT_ID,
+      grant_type: 'refresh_token',
+      refresh_token: refreshToken
+    });
+    const res = await fetch('https://oauth2.googleapis.com/token', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body: payload.toString()
+    });
+    const data = await res.json().catch(() => ({}));
+    if(!res.ok || data.error || !data.access_token) {
+      localStorage.removeItem('youtube_access_token');
+      localStorage.removeItem('youtube_refresh_token');
+      localStorage.removeItem('youtube_token_expiry');
+      S.tokens.youtube = null;
+      throw new Error(data.error_description || data.error || `HTTP ${res.status}`);
+    }
+    saveYouTubeTokens(data);
+    S.tokens.youtube = data.access_token;
+    return data.access_token;
+  })();
+
+  try {
+    return await S.youtubeRefreshPromise;
+  } finally {
+    S.youtubeRefreshPromise = null;
+  }
+}
+
+async function getYouTubeAccessToken(forceRefresh = false) {
+  const token = S.tokens.youtube || localStorage.getItem('youtube_access_token') || '';
+  if(!token) return '';
+
+  const expiry = parseInt(localStorage.getItem('youtube_token_expiry') || '0', 10);
+  const hasRefreshToken = !!localStorage.getItem('youtube_refresh_token');
+  const shouldRefresh = forceRefresh || (hasRefreshToken && expiry <= Date.now() + 120000);
+
+  if(shouldRefresh) {
+    return refreshYouTubeToken(true);
+  }
+  return token;
+}
 
 // On page load, check if we're the OAuth redirect landing inside a popup.
 // If so, pass the token back to the parent window and close immediately.
@@ -450,6 +543,36 @@ function ftime(){const d=new Date();return `${d.getHours().toString().padStart(2
   if(!platform || !CFG[platform]) return;
 
   if(window.opener && !window.opener.closed) {
+    if(code && platform === 'youtube') {
+      const verifier = window.opener.sessionStorage?.getItem('youtube_verifier')
+                    || sessionStorage.getItem('youtube_verifier');
+      exchangeYouTubeCodeForToken(code, verifier)
+      .then(d => {
+        window.opener.sessionStorage?.removeItem('youtube_verifier');
+        sessionStorage.removeItem('youtube_verifier');
+        window.opener.postMessage({
+          type: 'oauth_callback',
+          platform: 'youtube',
+          token: d.access_token || null,
+          refresh_token: d.refresh_token || null,
+          expires_in: d.expires_in || null,
+          error: null,
+          errorDesc: null
+        }, window.location.origin);
+        window.close();
+      })
+      .catch(e => {
+        window.opener.postMessage({
+          type: 'oauth_callback',
+          platform: 'youtube',
+          token: null,
+          error: e.message
+        }, window.location.origin);
+        window.close();
+      });
+      return;
+    }
+
     if(code && platform === 'kick') {
       // Kick PKCE: exchange the code for a token via the local proxy server,
       // then post the resulting token back to the parent window
@@ -483,7 +606,7 @@ function ftime(){const d=new Date();return `${d.getHours().toString().padStart(2
       return;
     }
 
-    // Twitch / YouTube implicit flow — token is in the hash directly
+    // Twitch implicit flow — token is in the hash directly
     window.opener.postMessage({
       type: 'oauth_callback', platform,
       token: token || null,
@@ -493,7 +616,23 @@ function ftime(){const d=new Date();return `${d.getHours().toString().padStart(2
     return;
   }
 
-  // Fallback: main tab full-page redirect (implicit flow only)
+  // Fallback: main tab full-page redirect
+  if(code && platform === 'youtube') {
+    const verifier = sessionStorage.getItem('youtube_verifier');
+    exchangeYouTubeCodeForToken(code, verifier)
+      .then(d => {
+        sessionStorage.removeItem('youtube_verifier');
+        saveYouTubeTokens(d);
+        history.replaceState(null, '', window.location.pathname);
+        markConnected('youtube', d.access_token);
+      })
+      .catch(e => {
+        history.replaceState(null, '', window.location.pathname);
+        showToast(`YouTube auth failed: ${e.message}`);
+      });
+    return;
+  }
+
   if(token) {
     history.replaceState(null, '', window.location.pathname);
     markConnected(platform, token);
@@ -558,26 +697,34 @@ function restoreTwitchSession() {
 }
 
 function restoreYouTubeSession() {
-  const token = localStorage.getItem('youtube_access_token');
-  if(!token) return;
+  const token = localStorage.getItem('youtube_access_token') || '';
+  const refreshToken = localStorage.getItem('youtube_refresh_token') || '';
+  if(!token && !refreshToken) return;
 
-  // Validate quietly with an authenticated YouTube API request instead of
-  // oauth2/v1/tokeninfo so we avoid noisy 400 errors in the console.
-  fetch('https://www.googleapis.com/youtube/v3/channels?part=id&mine=true', {
-    headers: { 'Authorization': `Bearer ${token}` }
-  })
-  .then(async r => {
-    const d = await r.json().catch(() => ({}));
-    if(!r.ok || d?.error || !d?.items?.length) {
-      throw new Error(d?.error?.message || `HTTP ${r.status}`);
-    }
-    return d;
-  })
-  .then(() => markConnected('youtube', token))
-  .catch(() => {
-    localStorage.removeItem('youtube_access_token');
-    resetConnectBtn('youtube');
-  });
+  getYouTubeAccessToken()
+    .then(accessToken => {
+      if(!accessToken) throw new Error('Missing access token');
+      return fetch('https://www.googleapis.com/youtube/v3/channels?part=id&mine=true', {
+        headers: { 'Authorization': `Bearer ${accessToken}` }
+      });
+    })
+    .then(async r => {
+      const d = await r.json().catch(() => ({}));
+      if(!r.ok || d?.error || !d?.items?.length) {
+        throw new Error(d?.error?.message || `HTTP ${r.status}`);
+      }
+      return d;
+    })
+    .then(() => {
+      const accessToken = S.tokens.youtube || localStorage.getItem('youtube_access_token');
+      if(accessToken) markConnected('youtube', accessToken);
+    })
+    .catch(() => {
+      localStorage.removeItem('youtube_access_token');
+      localStorage.removeItem('youtube_refresh_token');
+      localStorage.removeItem('youtube_token_expiry');
+      resetConnectBtn('youtube');
+    });
 }
 
 // Kick uses PKCE Authorization Code flow via the local proxy server.
@@ -588,6 +735,7 @@ function startOAuth(p) {
     return;
   }
   if(p === 'kick') { startKickOAuth(); return; }
+  if(p === 'youtube') { startYouTubeOAuth(); return; }
 
   S.currentPlatform = p;
   const c = CFG[p];
@@ -653,6 +801,74 @@ function startOAuth(p) {
       window.removeEventListener('message', onMessage);
       if(!S.tokens[p]) {
         resetConnectBtn(p);
+        showToast('Authorization cancelled');
+      }
+    }
+  }, 400);
+}
+
+async function startYouTubeOAuth() {
+  const btn = document.getElementById('btn-youtube');
+  btn.textContent = 'Connecting...';
+  btn.className = 'conn-btn pending';
+
+  S.currentPlatform = 'youtube';
+  const { verifier, challenge } = await generatePKCE();
+  sessionStorage.setItem('youtube_verifier', verifier);
+
+  const redirectUri = encodeURIComponent(getRedirectUri());
+  const scope = encodeURIComponent('https://www.googleapis.com/auth/youtube.force-ssl');
+  const oauthUrl = `https://accounts.google.com/o/oauth2/v2/auth`
+    + `?client_id=${encodeURIComponent(YOUTUBE_CLIENT_ID)}`
+    + `&response_type=code`
+    + `&redirect_uri=${redirectUri}`
+    + `&scope=${scope}`
+    + `&access_type=offline`
+    + `&prompt=consent`
+    + `&code_challenge=${challenge}`
+    + `&code_challenge_method=S256`
+    + `&state=youtube`;
+
+  const width = 500, height = 700;
+  const left = Math.round(window.screenX + (window.outerWidth - width) / 2);
+  const top = Math.round(window.screenY + (window.outerHeight - height) / 2);
+  const popup = window.open(oauthUrl, 'youtube_oauth', `width=${width},height=${height},left=${left},top=${top},toolbar=no,menubar=no`);
+
+  if(!popup) {
+    showToast('Popup blocked — redirecting in current tab...');
+    setTimeout(() => { window.location.href = oauthUrl; }, 1000);
+    return;
+  }
+
+  function onMessage(e) {
+    if(e.origin !== window.location.origin) return;
+    if(!e.data || e.data.type !== 'oauth_callback' || e.data.platform !== 'youtube') return;
+    window.removeEventListener('message', onMessage);
+    clearInterval(closedPoll);
+
+    if(e.data.token) {
+      saveYouTubeTokens({
+        access_token: e.data.token,
+        refresh_token: e.data.refresh_token,
+        expires_in: e.data.expires_in
+      });
+      markConnected('youtube', e.data.token);
+    } else {
+      resetConnectBtn('youtube');
+      const desc = (e.data.errorDesc || e.data.error || 'unknown error').replace(/\+/g,' ');
+      showToast(`Auth failed: ${desc}`);
+    }
+  }
+  window.addEventListener('message', onMessage);
+
+  const closedPoll = setInterval(() => {
+    let wasClosed = false;
+    try { wasClosed = !!popup.closed; } catch(_) { return; }
+    if(wasClosed) {
+      clearInterval(closedPoll);
+      window.removeEventListener('message', onMessage);
+      if(!S.tokens.youtube) {
+        resetConnectBtn('youtube');
         showToast('Authorization cancelled');
       }
     }
@@ -878,7 +1094,12 @@ function disconnectPlatform(p) {
     localStorage.removeItem('kick_token_expiry');
   }
   if(p === 'twitch')  { localStorage.removeItem('twitch_access_token');  S.twitchUserLogin  = null; S.twitchUserId = null; }
-  if(p === 'youtube') { localStorage.removeItem('youtube_access_token'); S.youtubeUserName  = null; }
+  if(p === 'youtube') {
+    localStorage.removeItem('youtube_access_token');
+    localStorage.removeItem('youtube_refresh_token');
+    localStorage.removeItem('youtube_token_expiry');
+    S.youtubeUserName  = null;
+  }
   if(p === 'kick')    { S.kickUserLogin = null; }
   document.getElementById(`row-${p}`).className = 'oauth-row';
   document.getElementById(`sd-${p}`).className = 'status-dot off';
@@ -1452,11 +1673,12 @@ function connectYouTube(input) {
 
   addSys(`Connecting to YouTube: ${videoId}...`);
 
-  const token = S.tokens.youtube || localStorage.getItem('youtube_access_token') || '';
-  const headers = token ? { 'Authorization': `Bearer ${token}` } : {};
-  const keyParam = (!token && YOUTUBE_API_KEY) ? `&key=${YOUTUBE_API_KEY}` : '';
-
-  fetch(`https://www.googleapis.com/youtube/v3/videos?part=liveStreamingDetails,snippet&id=${videoId}${keyParam}`, { headers })
+  getYouTubeAccessToken()
+    .then(token => {
+      const headers = token ? { 'Authorization': `Bearer ${token}` } : {};
+      const keyParam = (!token && YOUTUBE_API_KEY) ? `&key=${YOUTUBE_API_KEY}` : '';
+      return fetch(`https://www.googleapis.com/youtube/v3/videos?part=liveStreamingDetails,snippet&id=${videoId}${keyParam}`, { headers });
+    })
     .then(r => r.json())
     .then(data => {
       if(data.error) {
@@ -1492,10 +1714,10 @@ function connectYouTube(input) {
     .catch(e => addSys(`YouTube: failed to fetch video details — ${e.message}`));
 }
 
-function pollYouTube(videoId, liveChatId, apiKey, pageToken) {
+async function pollYouTube(videoId, liveChatId, apiKey, pageToken) {
   if(S.channels.youtube !== videoId) return;
 
-  const token = S.tokens.youtube || localStorage.getItem('youtube_access_token') || '';
+  const token = await getYouTubeAccessToken();
   const useOAuth = !!token;
   const params = new URLSearchParams({
     liveChatId,
@@ -1513,6 +1735,13 @@ function pollYouTube(videoId, liveChatId, apiKey, pageToken) {
     .then(async r => {
       const data = await r.json().catch(() => ({}));
       if(!r.ok || data?.error) {
+        if(r.status === 401 && useOAuth) {
+          const refreshed = await getYouTubeAccessToken(true).catch(() => '');
+          if(refreshed && S.channels.youtube === videoId) {
+            pollYouTube(videoId, liveChatId, apiKey, pageToken);
+            return null;
+          }
+        }
         const msg = data?.error?.message || `HTTP ${r.status}`;
         const code = data?.error?.code ? ` (${data.error.code})` : '';
         throw new Error(`${msg}${code}`);
@@ -1520,6 +1749,7 @@ function pollYouTube(videoId, liveChatId, apiKey, pageToken) {
       return data;
     })
     .then(data => {
+      if(!data) return;
       if(S.channels.youtube !== videoId) return;
 
       let shown = 0;
@@ -2477,7 +2707,8 @@ async function sendKick(text) {
 }
 
 async function sendYouTube(text) {
-  const token = S.tokens.youtube;
+  const token = await getYouTubeAccessToken();
+  if(!token) { addSys('YouTube: please reconnect your account'); return; }
   if(!S.youtubeLiveChatId) { addSys('YouTube: no live chat ID — join a channel first'); return; }
   try {
     const res = await fetch('https://www.googleapis.com/youtube/v3/liveChat/messages?part=snippet', {


### PR DESCRIPTION
### Motivation
- YouTube access tokens obtained via the implicit flow were short-lived and caused 401 errors ("Request had invalid authentication credentials") during long live chat sessions, forcing users to disconnect/reconnect.
- The intent is to keep YouTube sessions alive by adding a refresh-capable OAuth flow and automatic token renewal so polling and sends do not fail every hour.

### Description
- Switched YouTube OAuth to Authorization Code + PKCE by adding `startYouTubeOAuth`, PKCE generation, and code exchange via `exchangeYouTubeCodeForToken` so refresh tokens can be obtained and used.
- Added token helpers: `saveYouTubeTokens`, `refreshYouTubeToken`, and `getYouTubeAccessToken` to persist `youtube_access_token`, `youtube_refresh_token`, and `youtube_token_expiry` in `localStorage` and serialize refresh attempts with `S.youtubeRefreshPromise`.
- Updated restore/connect/poll/send flows to call `getYouTubeAccessToken` and to automatically refresh on expiry or when a 401 is encountered during polling, plus a retry path after successful refresh; also updated callback handling to exchange codes for tokens in both popup and full-page flows.
- Cleaned up disconnect behavior to remove all YouTube token artifacts (`youtube_access_token`, `youtube_refresh_token`, and `youtube_token_expiry`) and updated UI state handling accordingly.

### Testing
- Extracted the inline script and ran `node --check /tmp/friendly-chat-inline.js` to validate syntax, and the check completed successfully.
- Changes were committed with a descriptive message and the PR metadata was prepared via the repository tooling.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d6f588da04832187b6601150a037f2)