### PR TITLE
Fix YouTube OAuth callback persistence in popup flow

### DIFF
--- a/friendly-chat.html
+++ b/friendly-chat.html
@@ -478,9 +478,6 @@ function emitOAuthCallback(platform, payload) {
       type: 'oauth_callback',
       ts: Date.now()
     }));
-    // Remove immediately so future attempts can reuse the same key and so we
-    // don't accidentally process stale callbacks on reload.
-    localStorage.removeItem(key);
   } catch(_) {}
 }
 
@@ -913,11 +910,29 @@ async function startYouTubeOAuth() {
   }
 
   const callbackStorageKey = 'oauth_callback_youtube';
+  function consumeStoredOAuthCallback() {
+    const raw = localStorage.getItem(callbackStorageKey);
+    if(!raw) return false;
+    try {
+      const data = JSON.parse(raw);
+      if(data?.type === 'oauth_callback' && data?.platform === 'youtube') {
+        // Ignore very old callbacks to avoid replaying stale auth results.
+        if(!data.ts || (Date.now() - data.ts) < 300000) {
+          handleYouTubeOAuthResult(data);
+          return true;
+        }
+      }
+    } catch(_) {}
+    return false;
+  }
+
   function handleYouTubeOAuthResult(data) {
     if(!data || data.type !== 'oauth_callback' || data.platform !== 'youtube') return;
     window.removeEventListener('message', onMessage);
     window.removeEventListener('storage', onStorage);
+    clearInterval(callbackPoll);
     clearInterval(closedPoll);
+    localStorage.removeItem(callbackStorageKey);
 
     if(data.token) {
       saveYouTubeTokens({
@@ -948,11 +963,18 @@ async function startYouTubeOAuth() {
   }
   window.addEventListener('storage', onStorage);
 
+  const callbackPoll = setInterval(() => {
+    if(consumeStoredOAuthCallback()) {
+      clearInterval(callbackPoll);
+    }
+  }, 300);
+
   const closedPoll = setInterval(() => {
     let wasClosed = false;
     try { wasClosed = !!popup.closed; } catch(_) { return; }
     if(wasClosed) {
       clearInterval(closedPoll);
+      clearInterval(callbackPoll);
       window.removeEventListener('message', onMessage);
       window.removeEventListener('storage', onStorage);
       if(!S.tokens.youtube) {


### PR DESCRIPTION
### Motivation
- Prevent a race where the YouTube OAuth popup writes its callback to `localStorage` then immediately removes it, causing the main window to miss the auth result and leave YouTube disconnected.
- Provide a reliable fallback for Electron/popup flows where `postMessage` or `storage` events may not be reliably delivered.

### Description
- Stop immediately deleting the `oauth_callback_*` entry after writing it in `emitOAuthCallback`, so other windows can read the payload.
- Add a stored-callback consumer in `startYouTubeOAuth()` that polls `oauth_callback_youtube`, validates the payload, ignores callbacks older than 5 minutes, and invokes the existing handler when found.
- Ensure all timers and event listeners (`postMessage`, `storage`, polling interval`) are cleaned up when the callback is handled or the popup is closed.

### Testing
- Verified the inline script in `friendly-chat.html` can be parsed/executed via `node` using `new Function(...)` to catch syntax errors, and it succeeded.
- Verified the resulting diff of `friendly-chat.html` contains the intended changes and that the new polling/cleanup logic is present and syntactically valid.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d70459b0f48321b11448dc91fac487)