### PR TITLE
Support YouTube OAuth token exchange/refresh with optional client_secret

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,22 @@ npm run build:mac    # Mac
 npm run build:linux  # Linux
 ```
 
+### YouTube OAuth note
+
+If your Google OAuth client is configured as a **Web application**, Google may require a `client_secret` during token exchange.  
+Add it to your local `config.json`:
+
+```json
+{
+  "youtube": {
+    "client_id": "YOUR_CLIENT_ID",
+    "client_secret": "YOUR_CLIENT_SECRET"
+  }
+}
+```
+
+`client_secret` is optional in Friendly Chat, but required for some Google OAuth client setups.
+
 ---
 
 ## Built with

--- a/server.js
+++ b/server.js
@@ -108,6 +108,88 @@ function start(CFG) {
       return;
     }
 
+    // ── /youtube-token — exchange code for token locally (optional client secret)
+    if(pathname === '/youtube-token' && req.method === 'POST') {
+      try {
+        const { code, code_verifier, redirect_uri, client_id } = await readBody(req);
+        const youtubeClientId = client_id || CFG.youtube?.client_id || '';
+        const youtubeClientSecret = CFG.youtube?.client_secret || '';
+        const params = new URLSearchParams({
+          grant_type: 'authorization_code',
+          client_id: youtubeClientId,
+          code_verifier,
+          code,
+          redirect_uri: redirect_uri || `http://localhost:${PORT}/friendly-chat.html`,
+        });
+        if(youtubeClientSecret) {
+          params.set('client_secret', youtubeClientSecret);
+        }
+        const ytRes = await fetch('https://oauth2.googleapis.com/token', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+          body: params.toString(),
+        });
+        const data = await ytRes.json().catch(() => ({}));
+        if(!ytRes.ok || data.error) {
+          res.writeHead(ytRes.status || 400, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify({
+            error: data.error_description || data.error || 'YouTube token exchange failed',
+          }));
+          return;
+        }
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({
+          access_token: data.access_token,
+          refresh_token: data.refresh_token,
+          expires_in: data.expires_in,
+        }));
+      } catch(e) {
+        res.writeHead(500, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ error: e.message }));
+      }
+      return;
+    }
+
+    // ── /youtube-refresh — refresh token locally (optional client secret) ─────
+    if(pathname === '/youtube-refresh' && req.method === 'POST') {
+      try {
+        const { refresh_token, client_id } = await readBody(req);
+        const youtubeClientId = client_id || CFG.youtube?.client_id || '';
+        const youtubeClientSecret = CFG.youtube?.client_secret || '';
+        const params = new URLSearchParams({
+          grant_type: 'refresh_token',
+          client_id: youtubeClientId,
+          refresh_token,
+        });
+        if(youtubeClientSecret) {
+          params.set('client_secret', youtubeClientSecret);
+        }
+        const ytRes = await fetch('https://oauth2.googleapis.com/token', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+          body: params.toString(),
+        });
+        const data = await ytRes.json().catch(() => ({}));
+        if(!ytRes.ok || data.error || !data.access_token) {
+          res.writeHead(ytRes.status || 400, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify({
+            error: data.error_description || data.error || 'YouTube token refresh failed',
+          }));
+          return;
+        }
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({
+          access_token: data.access_token,
+          refresh_token: data.refresh_token || refresh_token,
+          expires_in: data.expires_in,
+        }));
+      } catch(e) {
+        res.writeHead(500, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ error: e.message }));
+      }
+      return;
+    }
+
     // ── /kick-send — uses user's own access token, no secret needed ──────────
     if(pathname === '/kick-send' && req.method === 'POST') {
       try {


### PR DESCRIPTION
### Motivation
- YouTube OAuth was failing with `client_secret is missing.` for Google OAuth clients configured as Web applications that require a client secret during token exchange.  
- The app must support both PKCE-only flows and client_secret-required flows without embedding secrets in frontend code.  

### Description
- Added a local `POST /youtube-token` endpoint in `server.js` that exchanges an auth code with Google and will include `CFG.youtube.client_secret` when present.  
- Added a local `POST /youtube-refresh` endpoint in `server.js` that refreshes YouTube tokens and will include `CFG.youtube.client_secret` when present.  
- Documented the optional `youtube.client_secret` field in `config.json` in the `README.md` so users with Web-type Google clients can add the secret locally.  

### Testing
- Ran `node --check server.js` which completed without errors.  
- Ran `node --check proxy-server.js` which completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d71664cb888321af59898be9ca34f7)