### PR TITLE
Use local server for YouTube OAuth token exchange and improve missing-secret errors

### DIFF
--- a/friendly-chat.html
+++ b/friendly-chat.html
@@ -365,6 +365,7 @@ let YOUTUBE_CLIENT_ID = '';
 let YOUTUBE_API_KEY   = '';
 let TWITCH_CLIENT_ID  = '';
 let KICK_CLIENT_ID_PUB = '';
+let YOUTUBE_HAS_CLIENT_SECRET = false;
 
 async function loadConfig(retries = 5, delayMs = 800) {
   dbg('config', 'Loading /config', { retries, delayMs });
@@ -376,9 +377,11 @@ async function loadConfig(retries = 5, delayMs = 800) {
       TWITCH_CLIENT_ID   = c.twitch?.client_id  || '';
       YOUTUBE_CLIENT_ID  = c.youtube?.client_id || '';
       YOUTUBE_API_KEY    = c.youtube?.api_key   || '';
+      YOUTUBE_HAS_CLIENT_SECRET = !!c.youtube?.has_client_secret;
       KICK_CLIENT_ID_PUB = c.kick?.client_id    || '';
       dbg('config', 'Loaded /config successfully', {
         hasYoutubeClientId: !!YOUTUBE_CLIENT_ID,
+        hasYoutubeClientSecret: YOUTUBE_HAS_CLIENT_SECRET,
         hasKickClientId: !!KICK_CLIENT_ID_PUB,
         hasTwitchClientId: !!TWITCH_CLIENT_ID
       });
@@ -570,17 +573,15 @@ async function exchangeYouTubeCodeForToken(code, codeVerifier) {
     hasVerifier: !!codeVerifier
   });
   await ensureYouTubeClientId();
-  const payload = new URLSearchParams({
-    client_id: YOUTUBE_CLIENT_ID,
-    code,
-    code_verifier: codeVerifier,
-    grant_type: 'authorization_code',
-    redirect_uri: getRedirectUri()
-  });
-  const res = await fetch('https://oauth2.googleapis.com/token', {
+  const res = await fetch('/youtube-token', {
     method: 'POST',
-    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-    body: payload.toString()
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      client_id: YOUTUBE_CLIENT_ID,
+      code,
+      code_verifier: codeVerifier,
+      redirect_uri: getRedirectUri(),
+    })
   });
   const data = await res.json().catch(() => ({}));
   if(!res.ok || data.error) {
@@ -588,7 +589,15 @@ async function exchangeYouTubeCodeForToken(code, codeVerifier) {
       status: res.status,
       error: data.error || data.error_description || 'unknown'
     });
-    throw new Error(data.error_description || data.error || `HTTP ${res.status}`);
+    const err = data.error_description || data.error || `HTTP ${res.status}`;
+    if(String(err).toLowerCase().includes('client_secret is missing')) {
+      throw new Error(
+        YOUTUBE_HAS_CLIENT_SECRET
+          ? 'YouTube rejected the OAuth app configuration. Confirm the Google OAuth client type and redirect URI.'
+          : 'YouTube OAuth requires a client secret for this Google OAuth app. Add youtube.client_secret to config.json or use an OAuth client type that supports PKCE-only flows.'
+      );
+    }
+    throw new Error(err);
   }
   dbg('youtube.oauth', 'Token exchange success', {
     hasAccessToken: !!data.access_token,
@@ -611,15 +620,13 @@ async function refreshYouTubeToken(force = false) {
 
   S.youtubeRefreshPromise = (async () => {
     await ensureYouTubeClientId();
-    const payload = new URLSearchParams({
-      client_id: YOUTUBE_CLIENT_ID,
-      grant_type: 'refresh_token',
-      refresh_token: refreshToken
-    });
-    const res = await fetch('https://oauth2.googleapis.com/token', {
+    const res = await fetch('/youtube-refresh', {
       method: 'POST',
-      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-      body: payload.toString()
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        client_id: YOUTUBE_CLIENT_ID,
+        refresh_token: refreshToken
+      })
     });
     const data = await res.json().catch(() => ({}));
     if(!res.ok || data.error || !data.access_token) {

--- a/server.js
+++ b/server.js
@@ -51,7 +51,10 @@ function start(CFG) {
       res.writeHead(200, { 'Content-Type': 'application/json' });
       res.end(JSON.stringify({
         twitch:  { client_id: CFG.twitch?.client_id  || '' },
-        youtube: { client_id: CFG.youtube?.client_id || '' },
+        youtube: {
+          client_id: CFG.youtube?.client_id || '',
+          has_client_secret: !!CFG.youtube?.client_secret,
+        },
         kick:    { client_id: kickClientId },
         has_kick_proxy: HAS_PROXY,
       }));


### PR DESCRIPTION
### Motivation
- The OAuth callback indicated `client_secret is missing`, which happens when the renderer tries to exchange a YouTube auth code directly without a server-side secret available. 
- The app should support server-mediated token exchange (when `youtube.client_secret` is configured) and surface clearer guidance when a secret is required or misconfigured.

### Description
- Expose a non-sensitive boolean `youtube.has_client_secret` on the public `/config` response so the UI can detect whether a client secret is configured on the server (`server.js`).
- Add a frontend flag `YOUTUBE_HAS_CLIENT_SECRET` and load it from `/config` to include in debug output (`friendly-chat.html`).
- Route YouTube auth code exchange and refresh through the local endpoints by calling `POST /youtube-token` and `POST /youtube-refresh` (JSON payloads) from the renderer instead of calling Google token endpoints directly (`friendly-chat.html`).
- Improve error handling to detect Google’s `client_secret is missing` response and throw a clearer, actionable message telling the operator to add `youtube.client_secret` to `config.json` or adjust the OAuth client type (`friendly-chat.html`).

### Testing
- Ran `node --check server.js` and it succeeded. 
- Ran `node --check main.js` and it succeeded. 
- Ran `node --check preload.js` and it succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d718bf17008321b1c9bed1416a3993)