### PR TITLE
Add YouTube implicit OAuth fallback when no client secret

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ Add it to your local `config.json`:
 }
 ```
 
-`client_secret` is optional in Friendly Chat, but required for some Google OAuth client setups.
+`client_secret` is optional in Friendly Chat. When it is not set, Friendly Chat falls back to YouTube's implicit token flow (`response_type=token`), which can connect successfully but does not return a refresh token for silent renewals.
 
 ---
 

--- a/friendly-chat.html
+++ b/friendly-chat.html
@@ -978,21 +978,35 @@ async function startYouTubeOAuth() {
   btn.className = 'conn-btn pending';
 
   S.currentPlatform = 'youtube';
-  const { verifier, challenge } = await generatePKCE();
-  setPkceVerifier('youtube', verifier);
 
   const redirectUri = encodeURIComponent(getRedirectUri());
   const scope = encodeURIComponent('https://www.googleapis.com/auth/youtube.force-ssl');
-  const oauthUrl = `https://accounts.google.com/o/oauth2/v2/auth`
-    + `?client_id=${encodeURIComponent(YOUTUBE_CLIENT_ID)}`
-    + `&response_type=code`
-    + `&redirect_uri=${redirectUri}`
-    + `&scope=${scope}`
-    + `&access_type=offline`
-    + `&prompt=consent`
-    + `&code_challenge=${challenge}`
-    + `&code_challenge_method=S256`
-    + `&state=youtube`;
+  let oauthUrl = '';
+
+  if(YOUTUBE_HAS_CLIENT_SECRET) {
+    const { verifier, challenge } = await generatePKCE();
+    setPkceVerifier('youtube', verifier);
+    oauthUrl = `https://accounts.google.com/o/oauth2/v2/auth`
+      + `?client_id=${encodeURIComponent(YOUTUBE_CLIENT_ID)}`
+      + `&response_type=code`
+      + `&redirect_uri=${redirectUri}`
+      + `&scope=${scope}`
+      + `&access_type=offline`
+      + `&prompt=consent`
+      + `&code_challenge=${challenge}`
+      + `&code_challenge_method=S256`
+      + `&state=youtube`;
+  } else {
+    clearPkceVerifier('youtube');
+    oauthUrl = `https://accounts.google.com/o/oauth2/v2/auth`
+      + `?client_id=${encodeURIComponent(YOUTUBE_CLIENT_ID)}`
+      + `&response_type=token`
+      + `&redirect_uri=${redirectUri}`
+      + `&scope=${scope}`
+      + `&prompt=consent`
+      + `&state=youtube`;
+    dbg('youtube.oauth', 'Using implicit token flow because youtube.client_secret is not configured');
+  }
 
   const width = 500, height = 700;
   const left = Math.round(window.screenX + (window.outerWidth - width) / 2);


### PR DESCRIPTION
### Motivation
- Recent OAuth failures showed the app trying an authorization-code exchange without a client secret and failing with `client_secret is missing`. 
- The intent is to allow users who only have a YouTube `client_id` (no `client_secret`) to still connect. 
- When a `client_secret` is provided, the app should retain the refresh-capable Authorization Code + PKCE flow. 

### Description
- Updated the YouTube connect flow in `startYouTubeOAuth` to select the flow based on `YOUTUBE_HAS_CLIENT_SECRET`, using Authorization Code + PKCE (`response_type=code`) when a client secret is present and falling back to implicit token flow (`response_type=token`) when it is not. 
- When using implicit mode the code now calls `clearPkceVerifier('youtube')` to remove any stale PKCE verifier state before launching the OAuth popup. 
- The README (`README.md`) was updated to document the fallback behavior and to note the limitation that the implicit flow does not return a refresh token (so silent renewals are not available). 
- No changes were made to the server-side token endpoints; local exchange/refresh endpoints remain unchanged for setups that provide a `client_secret`. 

### Testing
- Ran `git diff --check` and it completed without issues. 
- Ran `node --check server.js` and it completed without issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d71aae128c8321ac7f3af37b309d65)