### PR TITLE
Fix OAuth connect buttons by removing frontend syntax error

### DIFF
--- a/friendly-chat.html
+++ b/friendly-chat.html
@@ -1606,7 +1606,6 @@ function connectTwitch(channel) {
               emoteMap[start] = { id, end };
             });
           });
-        });
       }
 
       if(S.channels.twitch === channel) {


### PR DESCRIPTION
### Motivation
- Connect buttons (Twitch/YouTube/Kick) were non-functional because the large inline script in `friendly-chat.html` failed to parse, preventing functions like `startOAuth()` from being defined. 
- The root cause was a stray `});` inside the Twitch emote parsing block that introduced a JavaScript syntax error.

### Description
- Removed the extra closing `});` from the Twitch emote tag parsing block in `friendly-chat.html` so the inline script parses correctly. 
- The change is limited to the inline client script and does not alter server-side behavior or OAuth flow logic.

### Testing
- Extracted the inline script to `/tmp/fc.js` and ran `node -c /tmp/fc.js`, which now passes syntax checking. 
- Ran `node -c main.js`, `node -c server.js`, and `node -c preload.js` for basic static syntax validation, all of which passed. 
- Verified the fix restores the runtime definition of `startOAuth()` so the Connect buttons can be handled by the frontend script.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d7fdf57f58832186883baf9d0f65c6)