### PR TITLE
Clear expired YouTube implicit OAuth tokens to prevent 401 poll loops

### DIFF
--- a/friendly-chat.html
+++ b/friendly-chat.html
@@ -622,6 +622,17 @@ async function getYouTubeAccessToken(forceRefresh = false) {
 
   const expiry = parseInt(localStorage.getItem('youtube_token_expiry') || '0', 10);
   const hasRefreshToken = !!localStorage.getItem('youtube_refresh_token');
+  const isExpired = expiry > 0 && expiry <= Date.now() + 120000;
+
+  // Implicit OAuth flow does not return a refresh token. Once the access token
+  // expires, stop sending it so read-only polling can fall back to API key mode.
+  if(!hasRefreshToken && isExpired) {
+    localStorage.removeItem('youtube_access_token');
+    localStorage.removeItem('youtube_token_expiry');
+    S.tokens.youtube = null;
+    return '';
+  }
+
   const shouldRefresh = forceRefresh || (hasRefreshToken && expiry <= Date.now() + 120000);
 
   if(shouldRefresh) {
@@ -1937,6 +1948,11 @@ async function pollYouTube(videoId, liveChatId, apiKey, pageToken) {
       const data = await r.json().catch(() => ({}));
       if(!r.ok || data?.error) {
         if(r.status === 401 && useOAuth) {
+          if(!localStorage.getItem('youtube_refresh_token')) {
+            localStorage.removeItem('youtube_access_token');
+            localStorage.removeItem('youtube_token_expiry');
+            S.tokens.youtube = null;
+          }
           const refreshed = await getYouTubeAccessToken(true).catch(() => '');
           if(refreshed && S.channels.youtube === videoId) {
             pollYouTube(videoId, liveChatId, apiKey, pageToken);


### PR DESCRIPTION
### Motivation
- Users connecting with YouTube via the implicit (no-refresh-token) OAuth flow hit repeated `401` "invalid authentication credentials" poll errors after the access token expires, so the app should stop reusing expired tokens and fall back to API-key read mode when possible.

### Description
- In `friendly-chat.html` the YouTube token handling was updated to clear stored access tokens when they expire and no refresh token exists, and to clear stale OAuth state on `401` responses so polling can fall back to API key mode instead of repeatedly sending invalid Bearer credentials.

### Testing
- Verified the inline script can be parsed/executed with the command `node -e "const fs=require('fs'); const html=fs.readFileSync('friendly-chat.html','utf8'); const m=html.match(/<script>([\s\S]*)<\/script>/); if(!m) throw new Error('script block not found'); new Function(m[1]); console.log('inline script parsed');"`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d80f94cf00832193ad10fe9bfc0477)