### PR TITLE
Fix YouTube OAuth popup close race condition

### DIFF
--- a/friendly-chat.html
+++ b/friendly-chat.html
@@ -1056,13 +1056,20 @@ async function startYouTubeOAuth() {
     try { wasClosed = !!popup.closed; } catch(_) { return; }
     if(wasClosed) {
       clearInterval(closedPoll);
-      clearInterval(callbackPoll);
-      window.removeEventListener('message', onMessage);
-      window.removeEventListener('storage', onStorage);
-      if(!S.tokens.youtube) {
-        resetConnectBtn('youtube');
-        showToast('Authorization cancelled');
-      }
+      // OAuth callbacks can race the popup close event in Electron.
+      // Give storage/message delivery a brief grace period before treating
+      // the close as a cancellation.
+      if(consumeStoredOAuthCallback()) return;
+      setTimeout(() => {
+        if(consumeStoredOAuthCallback()) return;
+        clearInterval(callbackPoll);
+        window.removeEventListener('message', onMessage);
+        window.removeEventListener('storage', onStorage);
+        if(!S.tokens.youtube) {
+          resetConnectBtn('youtube');
+          showToast('Authorization cancelled');
+        }
+      }, 800);
     }
   }, 400);
 }


### PR DESCRIPTION
### Motivation
- The YouTube OAuth popup close handler could mark authorization as cancelled if the popup closed before the app consumed the callback posted via `postMessage` or `localStorage`, causing successful sign-ins to be ignored. 
- The change aims to make the YouTube `Connect` flow reliable in environments like Electron where message/storage delivery can race the popup close event.

### Description
- Updated `startYouTubeOAuth` in `friendly-chat.html` to have the popup-close poll first attempt to `consumeStoredOAuthCallback()` and, if not consumed, wait a short grace period (`800ms`) before treating the close as a cancellation. 
- The handler now clears intervals and removes event listeners only after the grace period if no callback is received, avoiding premature `resetConnectBtn('youtube')` and `showToast('Authorization cancelled')` calls.

### Testing
- No automated tests are configured for this repository, so no automated test runs were performed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d8390870cc8321901ac60e3d9c9fb5)