### PR TITLE
Remove beta branding from app header

### DIFF
--- a/friendly-chat.html
+++ b/friendly-chat.html
@@ -72,7 +72,6 @@ body{font-family:'DM Sans',sans-serif;background:var(--bg);color:var(--text);hei
 #main-app.hidden{display:none;}
 .topbar{height:52px;background:var(--surface);border-bottom:1px solid var(--border);display:flex;align-items:center;padding:0 14px;gap:14px;flex-shrink:0;}
 .app-logo{font-family:'JetBrains Mono',monospace;font-size:13px;font-weight:600;letter-spacing:0.06em;display:flex;align-items:center;gap:8px;flex-shrink:0;}
-.logo-badge{background:var(--accent);color:#fff;font-size:9px;padding:2px 6px;border-radius:4px;letter-spacing:0.08em;}
 .ch-inputs{display:flex;gap:7px;flex:1;min-width:0;}
 .ch-wrap{display:flex;align-items:center;border-radius:8px;overflow:hidden;border:1px solid var(--border);background:var(--surface2);flex:1;min-width:0;transition:border-color 0.2s;}
 .ch-wrap:focus-within{border-color:var(--border2);}
@@ -267,7 +266,7 @@ body{font-family:'DM Sans',sans-serif;background:var(--bg);color:var(--text);hei
 
 <div id="main-app" class="hidden">
   <div class="topbar">
-    <div class="app-logo"><span>FRIENDLY CHAT</span><span class="logo-badge">BETA</span></div>
+    <div class="app-logo"><span>FRIENDLY CHAT</span></div>
     <div class="ch-inputs">
       <div class="ch-wrap" id="cw-twitch">
         <span class="plat-tag twitch">TWITCH</span>


### PR DESCRIPTION
### Motivation
- Remove the visible "BETA" branding from the app header so the UI no longer displays the beta badge.

### Description
- Removed the `<span class="logo-badge">BETA</span>` from the top bar in `friendly-chat.html` so the header now only shows `FRIENDLY CHAT`.
- Deleted the now-unused `.logo-badge` CSS rule from `friendly-chat.html`.

### Testing
- Ran `rg -n "BETA|beta|Beta" --glob '!node_modules/**' --glob '!*lock*' .` which returned no matches in application source files (success).
- Ran `rg -n "BETA|beta|Beta" --glob '!node_modules/**' .` which showed only `package-lock.json` (a dependency version containing `beta`), confirming there are no remaining app-level beta references; modified file is `friendly-chat.html` (success).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d856298dc88321bc12751dca4b24d0)