### PR TITLE
Request Twitch IRCv3 tags and commands on connection

### DIFF
--- a/friendly-chat.html
+++ b/friendly-chat.html
@@ -1074,6 +1074,12 @@ function connectTwitch(channel) {
   S.sockets.twitch = ws;
 
   ws.onopen = () => {
+    // Request IRCv3 tags + Twitch-specific commands BEFORE auth/join so that
+    // PRIVMSG lines arrive with @badges=, @emotes=, @display-name=, etc. and
+    // we receive USERSTATE / ROOMSTATE / CLEARCHAT. Without twitch.tv/tags the
+    // live-message path has no badges tag to render, even though history
+    // (from robotty's recent-messages API) ships tags out of the box.
+    ws.send('CAP REQ :twitch.tv/tags twitch.tv/commands');
     // Use real token if authenticated so Twitch sends USERSTATE with emote-sets
     if(S.tokens.twitch && S.twitchUserLogin) {
       ws.send(`PASS oauth:${S.tokens.twitch}`);


### PR DESCRIPTION
## Summary
Added IRCv3 capability requests to the Twitch WebSocket connection to enable receipt of message metadata and Twitch-specific IRC commands.

## Changes
- Send `CAP REQ :twitch.tv/tags twitch.tv/commands` immediately after WebSocket connection opens, before authentication and channel join
- This ensures PRIVMSG messages include Twitch-specific tags (@badges, @emotes, @display-name, etc.)
- Enables receipt of USERSTATE, ROOMSTATE, and CLEARCHAT IRC commands from Twitch

## Details
Previously, live messages lacked badge information because the IRCv3 tags capability was not requested. While historical messages from robotty's recent-messages API included tags by default, live messages had no way to render badges. By requesting the capabilities early in the connection lifecycle (before PASS/NICK/JOIN), the server will include all necessary metadata in subsequent PRIVMSG lines, providing feature parity between live and historical message rendering.

https://claude.ai/code/session_014cVucWn7hWGsTscK53AbLP