### PR TITLE
Reduce main window minimum width to 520

### DIFF
--- a/main.js
+++ b/main.js
@@ -41,7 +41,7 @@ let mainWindow;
 
 function createWindow() {
   mainWindow = new BrowserWindow({
-    width: 1280, height: 800, minWidth: 680, minHeight: 600,
+    width: 1280, height: 800, minWidth: 520, minHeight: 600,
     title: 'Friendly Chat',
     icon: process.platform === 'linux' ? path.join(__dirname, 'icon.png') : undefined,
     webPreferences: {


### PR DESCRIPTION
### Motivation
- Allow the app window to be resized narrower than before so users can use slimmer layouts and small screens.

### Description
- Lowered the Electron main window `minWidth` in `main.js` from `680` to `520`.

### Testing
- Ran `node --check main.js` to validate syntax and it completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd95280bfc832188fd20683d03a771)