### PR TITLE
Fix Kick moderator detection using auth headers

### DIFF
--- a/friendly-chat.html
+++ b/friendly-chat.html
@@ -1301,7 +1301,12 @@ function connectKick(channel, reconnectAttempt = 0) {
   addSys(`Connecting to Kick: ${channel}...`);
 
   // First fetch the channel info to get the chatroom ID
-  fetch(`https://kick.com/api/v1/channels/${channel}`)
+  // Include OAuth token when available so Kick can return current-user mod flags.
+  const kickHeaders = {};
+  if(S.tokens.kick) kickHeaders['Authorization'] = `Bearer ${S.tokens.kick}`;
+  fetch(`https://kick.com/api/v1/channels/${channel}`, {
+    headers: kickHeaders
+  })
     .then(r => { if(!r.ok) throw new Error(r.status); return r.json(); })
     .then(data => {
       const chatroomId = data.chatroom?.id;


### PR DESCRIPTION
### Motivation
- Kick channel lookup was performed anonymously, so Kick often did not return current-user moderation flags and moderator actions did not appear for authenticated moderators.

### Description
- Send the Kick OAuth `Authorization: Bearer <token>` header (when `S.tokens.kick` is present) in the `fetch('https://kick.com/api/v1/channels/{channel}')` call inside `connectKick` so the API can include `is_moderator` / `is_current_user_moderator` flags used by `S.canModerate.kick`.

### Testing
- No automated tests are configured for this repository, so no automated test runs were executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd95b6efcc8321a7bdf3f4e67b0658)