### PR TITLE
Remove Kick Railway proxy dependency and switch to local OAuth config

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,28 @@ Then try opening the app again. Alternatively go to **System Settings → Privac
 
 You can watch and read chats without signing in. Signing in is only required to send messages.
 
+## Kick OAuth setup (no Railway required)
+
+Friendly Chat now performs Kick token exchange locally, so you do **not** need to deploy a Railway/Render proxy.
+
+1. Create a Kick OAuth application in the Kick developer dashboard.
+2. Set the app redirect URL to:
+   - `http://localhost:8080/friendly-chat.html`
+3. Open `config.json` and add your Kick credentials:
+
+```json
+{
+  "twitch": { "client_id": "YOUR_TWITCH_CLIENT_ID" },
+  "kick": {
+    "client_id": "YOUR_KICK_CLIENT_ID",
+    "client_secret": "YOUR_KICK_CLIENT_SECRET"
+  },
+  "port": 8080
+}
+```
+
+If `kick.client_id` or `kick.client_secret` is missing, Kick sign-in will be disabled until they are provided.
+
 ## Development
 
 ```bash

--- a/config.json
+++ b/config.json
@@ -1,5 +1,5 @@
 {
   "twitch":  { "client_id": "6a1bqli3xxei93r1zu6msidt5xf4kj" },
-  "proxy_url": "https://friendly-chat-proxy-production.up.railway.app",
+  "kick":    { "client_id": "YOUR_KICK_CLIENT_ID", "client_secret": "YOUR_KICK_CLIENT_SECRET" },
   "port": 8080
 }

--- a/friendly-chat.html
+++ b/friendly-chat.html
@@ -539,7 +539,7 @@ function emitOAuthCallback(platform, payload) {
   if(window.opener && !window.opener.closed) {
 
     if(code && platform === 'kick') {
-      // Kick PKCE: exchange the code for a token via the local proxy server,
+      // Kick PKCE: exchange the code for a token via the local server,
       // then post the resulting token back to the parent window
       const verifier = window.opener.sessionStorage?.getItem('kick_verifier')
                     || sessionStorage.getItem('kick_verifier');
@@ -645,7 +645,7 @@ function restoreTwitchSession() {
   .catch(() => markConnected('twitch', token));
 }
 
-// Kick uses PKCE Authorization Code flow via the local proxy server.
+// Kick uses PKCE Authorization Code flow via the local server.
 // OAuth callback flow.
 function startOAuth(p) {
   dbg('oauth', 'Start requested', { platform: p, protocol: window.location.protocol });
@@ -725,8 +725,7 @@ function startOAuth(p) {
 
 // ── Kick PKCE OAuth flow ──────────────────────────────────────────────────────
 // Kick requires Authorization Code + PKCE. The code verifier stays in the
-// browser; the code exchange happens via the local proxy server (server.js)
-// which holds the client secret securely.
+// browser; the code exchange happens via the local server (server.js).
 
 function base64urlEncode(buf) {
   return btoa(String.fromCharCode(...new Uint8Array(buf)))
@@ -746,7 +745,7 @@ async function startKickOAuth() {
   btn.className = 'conn-btn pending';
 
   // Get Kick client ID — already loaded into KICK_CLIENT_ID_PUB from /config
-  // If still empty, try fetching directly from the proxy
+  // If still empty, try fetching /config once more
   let clientId = KICK_CLIENT_ID_PUB;
   if(!clientId) {
     try {
@@ -761,7 +760,7 @@ async function startKickOAuth() {
 
   if(!clientId) {
     resetConnectBtn('kick');
-    showToast('Kick: proxy not reachable — check your internet connection');
+    showToast('Kick OAuth is not configured. Add kick.client_id and kick.client_secret to config.json.');
     return;
   }
 

--- a/main.js
+++ b/main.js
@@ -4,8 +4,7 @@ const { app, BrowserWindow, shell, ipcMain } = require('electron');
 const path = require('path');
 const fs   = require('fs');
 
-// Start server immediately — config.json holds all public credentials,
-// Kick secret is on the cloud proxy (never on this machine).
+// Start server immediately — config.json holds app credentials.
 const cfg = JSON.parse(fs.readFileSync(path.join(__dirname, 'config.json'), 'utf8'));
 require('./server').start(cfg);
 

--- a/server.js
+++ b/server.js
@@ -1,6 +1,5 @@
 // Friendly Chat - Local Server
-// Kick OAuth calls are forwarded to the cloud proxy (which holds the secret).
-// No Kick credentials are stored locally.
+// Runs inside the Electron app and handles local OAuth/token requests.
 
 const http = require('http');
 const fs   = require('fs');
@@ -25,18 +24,10 @@ function readBody(req) {
 }
 
 function start(CFG) {
-  const PORT       = CFG.port || 8080;
-  const PROXY_URL  = (CFG.proxy_url || CFG.kick_proxy_url || '').replace(/\/$/, '');
-  const HAS_PROXY  = PROXY_URL && PROXY_URL !== 'YOUR_PROXY_URL_HERE';
-
-  // Pre-fetch Kick client ID from proxy at startup
-  let kickClientId = '';
-  if(HAS_PROXY) {
-    fetch(`${PROXY_URL}/kick-config`)
-      .then(r => r.ok ? r.json() : null)
-      .then(d => { if(d?.client_id) kickClientId = d.client_id; })
-      .catch(e => console.warn('Could not reach proxy for Kick config:', e.message));
-  }
+  const PORT = CFG.port || 8080;
+  const KICK_CLIENT_ID = CFG.kick?.client_id || '';
+  const KICK_CLIENT_SECRET = CFG.kick?.client_secret || '';
+  const HAS_KICK_OAUTH_CONFIG = !!(KICK_CLIENT_ID && KICK_CLIENT_SECRET);
 
   const server = http.createServer(async (req, res) => {
     const pathname = new URL(req.url, `http://localhost:${PORT}`).pathname;
@@ -51,31 +42,46 @@ function start(CFG) {
       res.writeHead(200, { 'Content-Type': 'application/json' });
       res.end(JSON.stringify({
         twitch:  { client_id: CFG.twitch?.client_id  || '' },
-        kick:    { client_id: kickClientId },
-        has_kick_proxy: HAS_PROXY,
+        kick:    { client_id: KICK_CLIENT_ID },
+        has_kick_oauth_config: HAS_KICK_OAUTH_CONFIG,
       }));
       return;
     }
 
-    // ── /kick-token — forward to cloud proxy ─────────────────────────────────
+    // ── /kick-token — exchanges auth code for access/refresh token ─────────
     if(pathname === '/kick-token' && req.method === 'POST') {
-      if(!HAS_PROXY) {
+      if(!HAS_KICK_OAUTH_CONFIG) {
         res.writeHead(503, { 'Content-Type': 'application/json' });
-        res.end(JSON.stringify({ error: 'Kick proxy not configured' }));
+        res.end(JSON.stringify({ error: 'Kick OAuth not configured in config.json' }));
         return;
       }
       try {
-        const body = await readBody(req);
-        // Add redirect_uri for the proxy
-        body.redirect_uri = `http://localhost:${PORT}/friendly-chat.html`;
-        const kickRes = await fetch(`${PROXY_URL}/kick-token`, {
+        const { code, code_verifier } = await readBody(req);
+        const params = new URLSearchParams({
+          grant_type:    'authorization_code',
+          client_id:     KICK_CLIENT_ID,
+          client_secret: KICK_CLIENT_SECRET,
+          redirect_uri:  `http://localhost:${PORT}/friendly-chat.html`,
+          code_verifier,
+          code,
+        });
+        const kickRes = await fetch('https://id.kick.com/oauth/token', {
           method:  'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body:    JSON.stringify(body),
+          headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+          body:    params.toString(),
         });
         const data = await kickRes.json();
-        res.writeHead(kickRes.status, { 'Content-Type': 'application/json' });
-        res.end(JSON.stringify(data));
+        if(!kickRes.ok) {
+          res.writeHead(400, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify({ error: data.error || 'token exchange failed' }));
+          return;
+        }
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({
+          access_token:  data.access_token,
+          refresh_token: data.refresh_token,
+          expires_in:    data.expires_in,
+        }));
       } catch(e) {
         res.writeHead(500, { 'Content-Type': 'application/json' });
         res.end(JSON.stringify({ error: e.message }));
@@ -83,23 +89,38 @@ function start(CFG) {
       return;
     }
 
-    // ── /kick-refresh — forward to cloud proxy ────────────────────────────────
+    // ── /kick-refresh — refreshes Kick access token ─────────────────────────
     if(pathname === '/kick-refresh' && req.method === 'POST') {
-      if(!HAS_PROXY) {
+      if(!HAS_KICK_OAUTH_CONFIG) {
         res.writeHead(503, { 'Content-Type': 'application/json' });
-        res.end(JSON.stringify({ error: 'Kick proxy not configured' }));
+        res.end(JSON.stringify({ error: 'Kick OAuth not configured in config.json' }));
         return;
       }
       try {
-        const body = await readBody(req);
-        const kickRes = await fetch(`${PROXY_URL}/kick-refresh`, {
+        const { refresh_token } = await readBody(req);
+        const params = new URLSearchParams({
+          grant_type:    'refresh_token',
+          client_id:     KICK_CLIENT_ID,
+          client_secret: KICK_CLIENT_SECRET,
+          refresh_token,
+        });
+        const kickRes = await fetch('https://id.kick.com/oauth/token', {
           method:  'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body:    JSON.stringify(body),
+          headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+          body:    params.toString(),
         });
         const data = await kickRes.json();
-        res.writeHead(kickRes.status, { 'Content-Type': 'application/json' });
-        res.end(JSON.stringify(data));
+        if(!kickRes.ok) {
+          res.writeHead(400, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify({ error: data.error || 'refresh failed' }));
+          return;
+        }
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({
+          access_token:  data.access_token,
+          refresh_token: data.refresh_token,
+          expires_in:    data.expires_in,
+        }));
       } catch(e) {
         res.writeHead(500, { 'Content-Type': 'application/json' });
         res.end(JSON.stringify({ error: e.message }));
@@ -211,7 +232,9 @@ function start(CFG) {
 
   server.listen(PORT, () => {
     console.log(`\n  Friendly Chat running on http://localhost:${PORT}\n`);
-    if(!HAS_PROXY) console.log('  ⚠  Kick proxy not configured — Kick OAuth will not work\n');
+    if(!HAS_KICK_OAUTH_CONFIG) {
+      console.log('  ⚠  Kick OAuth not configured in config.json — add kick.client_id/client_secret to enable Kick sign in\n');
+    }
   });
 
   return server;


### PR DESCRIPTION
### Motivation
- Remove the app's reliance on an externally hosted Railway/Render proxy for Kick OAuth and let the app perform token exchange/refresh locally. 
- Require users to supply their own Kick application `client_id` and `client_secret` so secrets are stored/configured locally in `config.json`.

### Description
- Implemented direct Kick token exchange and refresh in `server.js` using `kick.client_id` and `kick.client_secret` from `config.json` and removed proxy URL logic. 
- Updated `/config` JSON and startup messages to report `has_kick_oauth_config` instead of proxy availability. 
- Updated the frontend (`friendly-chat.html`) to use the local server for Kick PKCE exchanges and to show a clear message when Kick OAuth is not configured. 
- Added `kick` placeholders to `config.json` and documented local Kick OAuth setup and required redirect URI in `README.md`, and updated a comment in `main.js` to reflect the new local-credential model.

### Testing
- Ran `node --check server.js` which completed successfully. 
- Ran `node --check main.js` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e40ec2c978832194041f4effdd89ba)