### PR TITLE
Add YouTube live chat support with BYO OAuth client and quota-safe polling

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,15 @@
 # Friendly Chat
 
-A desktop app that merges live chat from Twitch and Kick into one unified window. Built with Electron.
+A desktop app that merges live chat from Twitch, Kick, and YouTube into one unified window. Built with Electron.
 
 ![Platform Support](https://img.shields.io/badge/platform-Windows%20%7C%20Mac%20%7C%20Linux-blue)
 ![Version](https://img.shields.io/badge/version-1.2.0-green)
 
 ## What it does
 
-Friendly Chat lets you watch and participate in Twitch and Kick chats in one place.
+Friendly Chat lets you watch and participate in Twitch, Kick, and YouTube chats in one place.
 
-- View Twitch + Kick chats in a single feed
+- View Twitch + Kick + YouTube chats in a single feed
 - Filter by platform
 - Send messages to one or both platforms at once
 - Load recent chat history when you join a channel
@@ -35,7 +35,7 @@ Then try opening the app again. Alternatively go to **System Settings → Privac
 ## Getting started
 
 1. Launch Friendly Chat
-2. Click **Accounts** and connect Twitch and/or Kick
+2. Click **Accounts** and connect Twitch, Kick, and/or YouTube
 3. Type a channel name and click **Join**
 4. Start chatting
 
@@ -63,6 +63,39 @@ Friendly Chat now performs Kick token exchange locally, so you do **not** need t
 
 If `kick.client_id` or `kick.client_secret` is missing, Kick sign-in will be disabled until they are provided.
 
+## YouTube OAuth setup (bring your own Google OAuth client)
+
+Friendly Chat supports YouTube live chat by using **your own Google OAuth client ID**.
+
+1. Open Google Cloud Console and create/select a project.
+2. Enable **YouTube Data API v3** for that project.
+3. Create an OAuth client ID (Desktop app or Web app works for local development).
+4. Add this redirect URI to the OAuth client:
+   - `http://localhost:8080/friendly-chat.html`
+5. Add your client ID to `config.json`:
+
+```json
+{
+  "twitch": { "client_id": "YOUR_TWITCH_CLIENT_ID" },
+  "kick": {
+    "client_id": "YOUR_KICK_CLIENT_ID",
+    "client_secret": "YOUR_KICK_CLIENT_SECRET"
+  },
+  "youtube": {
+    "client_id": "YOUR_GOOGLE_OAUTH_CLIENT_ID"
+  },
+  "port": 8080
+}
+```
+
+If `youtube.client_id` is missing, YouTube sign-in will be disabled until it is provided.
+
+### YouTube quota behavior (10-hour session safety)
+
+The default YouTube Data API allocation is typically **10,000 units/day**. To reduce the chance of quota exhaustion during long sessions, Friendly Chat now enforces a **minimum YouTube poll interval of 20 seconds** when reading live chat. This keeps chat polling around ~1,800 calls over 10 hours, which is designed to stay within typical daily quota limits for most single-session use.
+
+You can still request additional quota from Google if you need higher throughput.
+
 ## Development
 
 ```bash
@@ -85,5 +118,6 @@ npm run build:linux
 - [Electron](https://www.electronjs.org)
 - [Twitch IRC](https://dev.twitch.tv/docs/irc/)
 - [Kick Pusher WebSocket](https://kick.com)
+- [YouTube Data API v3](https://developers.google.com/youtube/v3)
 - [BTTV](https://betterttv.com) / [7TV](https://7tv.app) emotes
 - [recent-messages.robotty.de](https://recent-messages.robotty.de) for Twitch chat history

--- a/config.json
+++ b/config.json
@@ -1,5 +1,6 @@
 {
   "twitch":  { "client_id": "6a1bqli3xxei93r1zu6msidt5xf4kj" },
   "kick":    { "client_id": "YOUR_KICK_CLIENT_ID", "client_secret": "YOUR_KICK_CLIENT_SECRET" },
+  "youtube": { "client_id": "YOUR_GOOGLE_OAUTH_CLIENT_ID" },
   "port": 8080
 }

--- a/friendly-chat.html
+++ b/friendly-chat.html
@@ -23,6 +23,9 @@
   --kick: #53fc18;
   --kick-dim: rgba(83,252,24,0.12);
   --kick-border: rgba(83,252,24,0.3);
+  --youtube: #ff3b30;
+  --youtube-dim: rgba(255,59,48,0.12);
+  --youtube-border: rgba(255,59,48,0.3);
   --accent: #7c6bff;
 }
 *{box-sizing:border-box;margin:0;padding:0;}
@@ -39,9 +42,11 @@ body{font-family:'DM Sans',sans-serif;background:var(--bg);color:var(--text);hei
 .oauth-row{display:flex;align-items:center;gap:14px;padding:14px 16px;border-radius:12px;border:1px solid var(--border);background:var(--surface2);transition:border-color 0.2s,background 0.2s;}
 .oauth-row.conn-twitch{border-color:var(--twitch-border);background:var(--twitch-dim);}
 .oauth-row.conn-kick{border-color:var(--kick-border);background:var(--kick-dim);}
+.oauth-row.conn-youtube{border-color:var(--youtube-border);background:var(--youtube-dim);}
 .plat-icon{width:36px;height:36px;border-radius:8px;display:flex;align-items:center;justify-content:center;flex-shrink:0;font-size:11px;font-weight:700;font-family:'JetBrains Mono',monospace;}
 .plat-icon.twitch{background:var(--twitch);color:#fff;}
 .plat-icon.kick{background:var(--kick);color:#0a0a0a;}
+.plat-icon.youtube{background:var(--youtube);color:#fff;}
 .plat-info{flex:1;}
 .plat-info strong{font-size:14px;font-weight:500;display:block;}
 .plat-info small{font-size:12px;color:var(--text-muted);}
@@ -51,6 +56,7 @@ body{font-family:'DM Sans',sans-serif;background:var(--bg);color:var(--text);hei
 .conn-btn{padding:7px 16px;border-radius:8px;font-size:12px;font-weight:500;font-family:'DM Sans',sans-serif;cursor:pointer;border:1px solid transparent;transition:all 0.15s;white-space:nowrap;}
 .conn-btn.twitch-c{background:var(--twitch);color:#fff;border-color:var(--twitch);}
 .conn-btn.kick-c{background:var(--kick);color:#0a0a0a;border-color:var(--kick);}
+.conn-btn.youtube-c{background:var(--youtube);color:#fff;border-color:var(--youtube);}
 .conn-btn.discon{background:transparent;border-color:var(--border2);color:var(--text-muted);}
 .conn-btn.discon:hover{border-color:#ff5555;color:#ff5555;}
 .conn-btn.pending{opacity:0.6;cursor:wait;}
@@ -70,9 +76,11 @@ body{font-family:'DM Sans',sans-serif;background:var(--bg);color:var(--text);hei
 .ch-wrap:focus-within{border-color:var(--border2);}
 .ch-wrap.act-twitch{border-color:var(--twitch-border);}
 .ch-wrap.act-kick{border-color:var(--kick-border);}
+.ch-wrap.act-youtube{border-color:var(--youtube-border);}
 .plat-tag{padding:0 9px;height:34px;display:flex;align-items:center;font-size:10px;font-weight:600;font-family:'JetBrains Mono',monospace;letter-spacing:0.05em;border-right:1px solid var(--border);white-space:nowrap;flex-shrink:0;}
 .plat-tag.twitch{color:var(--twitch);background:var(--twitch-dim);}
 .plat-tag.kick{color:var(--kick);background:var(--kick-dim);}
+.plat-tag.youtube{color:var(--youtube);background:var(--youtube-dim);}
 .ch-wrap input{flex:1;background:transparent;border:none;outline:none;padding:0 9px;font-size:12px;font-family:'JetBrains Mono',monospace;color:var(--text);height:34px;min-width:0;}
 .ch-wrap input::placeholder{color:var(--text-dim);}
 .join-btn{padding:0 12px;height:34px;border-radius:0;border:none;border-left:1px solid var(--border);background:transparent;color:var(--text-muted);font-size:11px;font-weight:500;font-family:'DM Sans',sans-serif;cursor:pointer;transition:all 0.15s;white-space:nowrap;flex-shrink:0;}
@@ -84,6 +92,7 @@ body{font-family:'DM Sans',sans-serif;background:var(--bg);color:var(--text);hei
 .acc-dot{width:6px;height:6px;border-radius:50%;background:var(--text-dim);transition:background 0.3s;}
 .acc-dot.on-twitch{background:var(--twitch);}
 .acc-dot.on-kick{background:var(--kick);}
+.acc-dot.on-youtube{background:var(--youtube);}
 
 .app-body{flex:1;display:flex;overflow:hidden;min-height:0;}
 .chat-col{flex:1;display:flex;flex-direction:column;overflow:hidden;min-height:0;}
@@ -105,6 +114,8 @@ body{font-family:'DM Sans',sans-serif;background:var(--bg);color:var(--text);hei
 .chip.twitch.on{opacity:1;}
 .chip.kick{border-color:var(--kick-border);color:var(--kick);background:var(--kick-dim);opacity:0.4;}
 .chip.kick.on{opacity:1;}
+.chip.youtube{border-color:var(--youtube-border);color:var(--youtube);background:var(--youtube-dim);opacity:0.4;}
+.chip.youtube.on{opacity:1;}
 .f-spacer{flex:1;}
 .msg-ct{font-size:calc(var(--chat-font-size) - 2px);font-family:'JetBrains Mono',monospace;color:var(--text-dim);}
 .feed{flex:1;overflow-y:auto;padding:6px 0;min-height:0;}
@@ -117,10 +128,12 @@ body{font-family:'DM Sans',sans-serif;background:var(--bg);color:var(--text);hei
 .m-dot{width:3px;height:3px;border-radius:50%;flex-shrink:0;margin-top:7px;}
 .m-dot.twitch{background:var(--twitch);}
 .m-dot.kick{background:var(--kick);}
+.m-dot.youtube{background:var(--youtube);}
 .m-time{font-size:10px;font-family:'JetBrains Mono',monospace;color:var(--text-muted);flex-shrink:0;min-width:38px;}
 .m-author{font-size:var(--chat-font-size);font-weight:500;flex-shrink:0;}
 .m-author.twitch{color:var(--twitch);}
 .m-author.kick{color:var(--kick);}
+.m-author.youtube{color:var(--youtube);}
 .m-colon{color:var(--text-dim);margin-right:3px;font-size:var(--chat-font-size);}
 .m-body{font-size:var(--chat-font-size);color:var(--text);line-height:1.4;word-break:break-word;}
 .chat-link{color:#7c9fff;text-decoration:underline;text-underline-offset:2px;word-break:break-all;}
@@ -157,6 +170,8 @@ body{font-family:'DM Sans',sans-serif;background:var(--bg);color:var(--text);hei
 .t-chip.twitch-t.sel{opacity:1;background:var(--twitch-dim);}
 .t-chip.kick-t{border-color:var(--kick-border);color:var(--kick);opacity:0.3;}
 .t-chip.kick-t.sel{opacity:1;background:var(--kick-dim);}
+.t-chip.youtube-t{border-color:var(--youtube-border);color:var(--youtube);opacity:0.3;}
+.t-chip.youtube-t.sel{opacity:1;background:var(--youtube-dim);}
 .t-chip.locked{opacity:0.15!important;cursor:not-allowed;}
 .send-row{display:flex;gap:8px;align-items:center;}
 .send-input{flex:1;background:var(--surface2);border:1px solid var(--border);border-radius:8px;padding:8px 12px;font-size:13px;font-family:'DM Sans',sans-serif;color:var(--text);outline:none;transition:border-color 0.2s;}
@@ -239,6 +254,12 @@ body{font-family:'DM Sans',sans-serif;background:var(--bg);color:var(--text);hei
         <div class="status-dot off" id="sd-kick"></div>
         <button class="conn-btn kick-c" id="btn-kick" onclick="startOAuth('kick')">Connect</button>
       </div>
+      <div class="oauth-row" id="row-youtube">
+        <div class="plat-icon youtube">YT</div>
+        <div class="plat-info"><strong>YouTube</strong><small id="st-youtube">Not connected</small></div>
+        <div class="status-dot off" id="sd-youtube"></div>
+        <button class="conn-btn youtube-c" id="btn-youtube" onclick="startOAuth('youtube')">Connect</button>
+      </div>
     </div>
     <div class="oauth-footer">
       <button class="skip-btn" onclick="dismiss()">Skip for now (read-only)</button>
@@ -261,11 +282,17 @@ body{font-family:'DM Sans',sans-serif;background:var(--bg);color:var(--text);hei
         <input type="text" id="ci-kick" placeholder="channel name" />
         <button class="join-btn" id="jb-kick" onclick="joinCh('kick')">Join</button>
       </div>
+      <div class="ch-wrap" id="cw-youtube">
+        <span class="plat-tag youtube">YOUTUBE</span>
+        <input type="text" id="ci-youtube" placeholder="live video URL or ID" />
+        <button class="join-btn" id="jb-youtube" onclick="joinCh('youtube')">Join</button>
+      </div>
     </div>
     <button class="acc-btn" onclick="openOAuth()">
       <div class="acc-dots">
         <div class="acc-dot" id="ad-twitch"></div>
         <div class="acc-dot" id="ad-kick"></div>
+        <div class="acc-dot" id="ad-youtube"></div>
       </div>
       <span>Accounts</span>
     </button>
@@ -280,6 +307,7 @@ body{font-family:'DM Sans',sans-serif;background:var(--bg);color:var(--text);hei
         <span class="chip all on" id="fc-all" onclick="toggleFilterAll()">ALL</span>
         <span class="chip twitch" id="fc-twitch" onclick="toggleFilter('twitch')">TWITCH</span>
         <span class="chip kick" id="fc-kick" onclick="toggleFilter('kick')">KICK</span>
+        <span class="chip youtube" id="fc-youtube" onclick="toggleFilter('youtube')">YOUTUBE</span>
         <div class="font-size-ctrl">
           <button class="fs-btn" onclick="adjustFontSize(-1)" title="Decrease font size">A−</button>
           <input type="number" id="fs-input" class="fs-input" value="13" min="9" max="22" title="Font size in px" onchange="setFontSizeFromInput()" onkeydown="if(event.key==='Enter') setFontSizeFromInput()">
@@ -301,6 +329,7 @@ body{font-family:'DM Sans',sans-serif;background:var(--bg);color:var(--text);hei
           <span class="t-chip all-t sel" id="tc-all" onclick="toggleTargetAll()">ALL</span>
           <span class="t-chip twitch-t" id="tc-twitch" onclick="toggleTarget('twitch')">TWITCH</span>
           <span class="t-chip kick-t" id="tc-kick" onclick="toggleTarget('kick')">KICK</span>
+          <span class="t-chip youtube-t" id="tc-youtube" onclick="toggleTarget('youtube')">YOUTUBE</span>
         </div>
         <div class="send-row">
           <button class="emote-btn" id="emote-btn" onclick="toggleEmotePicker()" title="Browse emotes">😊</button>
@@ -325,6 +354,7 @@ body{font-family:'DM Sans',sans-serif;background:var(--bg);color:var(--text);hei
 // Nothing sensitive is hardcoded here.
 let TWITCH_CLIENT_ID  = '';
 let KICK_CLIENT_ID_PUB = '';
+let YOUTUBE_CLIENT_ID_PUB = '';
 
 async function loadConfig(retries = 5, delayMs = 800) {
   dbg('config', 'Loading /config', { retries, delayMs });
@@ -335,9 +365,11 @@ async function loadConfig(retries = 5, delayMs = 800) {
       const c = await r.json();
       TWITCH_CLIENT_ID   = c.twitch?.client_id  || '';
       KICK_CLIENT_ID_PUB = c.kick?.client_id    || '';
+      YOUTUBE_CLIENT_ID_PUB = c.youtube?.client_id || '';
       dbg('config', 'Loaded /config successfully', {
         hasKickClientId: !!KICK_CLIENT_ID_PUB,
-        hasTwitchClientId: !!TWITCH_CLIENT_ID
+        hasTwitchClientId: !!TWITCH_CLIENT_ID,
+        hasYoutubeClientId: !!YOUTUBE_CLIENT_ID_PUB
       });
       CFG.twitch.url = `https://id.twitch.tv/oauth2/authorize?client_id=${TWITCH_CLIENT_ID}&scope=chat%3Aread+chat%3Aedit+user%3Awrite%3Achat+moderator%3Amanage%3Abanned_users+moderator%3Amanage%3Achat_messages+moderator%3Aread%3Afollowers+user%3Aread%3Aemotes&response_type=token`;
       return;
@@ -365,41 +397,52 @@ const CFG = {
     scopes:['Read your chat messages','Send chat messages','Access your channel information'],
     authBtnBg:'#53fc18', authBtnColor:'#0a0a0a', authBtnLabel:'Authorize with Kick',
     url: null
+  },
+  youtube: {
+    name:'YouTube', logoText:'YT', logoBg:'#ff3b30', logoColor:'#fff',
+    scopes:['Read live chat messages','Send live chat messages'],
+    authBtnBg:'#ff3b30', authBtnColor:'#fff', authBtnLabel:'Authorize with Google',
+    url: null
   }
 };
 
 const S = {
-  auth:{twitch:false,kick:false},
-  tokens:{twitch:null,kick:null},
-  channels:{twitch:null,kick:null},
+  auth:{twitch:false,kick:false,youtube:false},
+  tokens:{twitch:null,kick:null,youtube:null},
+  channels:{twitch:null,kick:null,youtube:null},
   filter: null, target: null, msgCount:0,
   currentPlatform:null,
-  sockets:{twitch:null,kick:null},
-  intervals:{twitch:null,kick:null},
+  sockets:{twitch:null,kick:null,youtube:null},
+  intervals:{twitch:null,kick:null,youtube:null,youtubeAuth:null},
   // Twitch send helpers — cached to avoid re-fetching on every message
   twitchUserId:null, twitchUserLogin:null,
   twitchBroadcasterId:null, twitchBroadcasterChannel:null,
   // Kick broadcaster ID cache
   kickBroadcasterId:null, kickBroadcasterChannel:null,
   kickUserLogin:null,
+  youtubeUserName:null,
+  youtubeLiveChatId:null,
+  youtubeVideoId:null,
+  youtubeNextPageToken:'',
+  youtubeSeenMessageIds:new Set(),
   // Third-party emote maps: { emoteName -> { url, source } }
   // Keyed per platform so Twitch and Kick have separate sets
-  thirdPartyEmotes: { twitch: {}, kick: {} },
+  thirdPartyEmotes: { twitch: {}, kick: {}, youtube: {} },
   // Native emotes fetched from platform APIs: { emoteName -> { url, source } }
-  nativeEmotes: { twitch: {}, kick: {} },
+  nativeEmotes: { twitch: {}, kick: {}, youtube: {} },
   // Twitch badge set cache { global: {setId -> versions}, channel: {setId -> versions} }
   twitchBadges: { global: {}, channel: {}, broadcasterId: null },
   // Recent chatters for @mention autocomplete { "platform:name" -> { name, platform } }
   recentChatters: new Map(),
   // Per-platform moderation capability for the currently joined channel
-  canModerate: { twitch: false, kick: false },
+  canModerate: { twitch: false, kick: false, youtube: false },
 };
 
 const KICK_EMOTE_CACHE_KEY = 'kick_emotes_cache_v1';
 const KICK_EMOTE_CACHE_TTL_MS = 7 * 24 * 60 * 60 * 1000;
 
 // ALL_PLATFORMS must be defined before S.filter and S.target are initialized
-const ALL_PLATFORMS = ['twitch','kick'];
+const ALL_PLATFORMS = ['twitch','kick','youtube'];
 S.filter = new Set(ALL_PLATFORMS);
 S.target = new Set(ALL_PLATFORMS);
 
@@ -571,6 +614,36 @@ function emitOAuthCallback(platform, payload) {
       return;
     }
 
+    if(code && platform === 'youtube') {
+      const verifier = getPkceVerifier('youtube', window.opener);
+      const redirectUri = getRedirectUri();
+      fetch('/youtube-token', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ code, code_verifier: verifier, redirect_uri: redirectUri }),
+      })
+      .then(r => r.json())
+      .then(d => {
+        window.opener.postMessage({
+          type: 'oauth_callback',
+          platform: 'youtube',
+          token: d.access_token || null,
+          refresh_token: d.refresh_token || null,
+          expires_in: d.expires_in || null,
+          error: d.error || null,
+        }, window.location.origin);
+        window.close();
+      })
+      .catch(e => {
+        window.opener.postMessage({
+          type: 'oauth_callback', platform: 'youtube',
+          token: null, error: e.message
+        }, window.location.origin);
+        window.close();
+      });
+      return;
+    }
+
     // Twitch implicit flow — token is in the hash directly
     window.opener.postMessage({
       type: 'oauth_callback', platform,
@@ -582,6 +655,28 @@ function emitOAuthCallback(platform, payload) {
   }
 
   // Fallback: main tab full-page redirect
+
+  if(code && platform === 'youtube') {
+    const verifier = getPkceVerifier('youtube');
+    fetch('/youtube-token', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ code, code_verifier: verifier, redirect_uri: getRedirectUri() }),
+    })
+    .then(r => r.json())
+    .then(d => {
+      if(d.access_token) {
+        localStorage.setItem('youtube_access_token', d.access_token);
+        if(d.refresh_token) localStorage.setItem('youtube_refresh_token', d.refresh_token);
+        localStorage.setItem('youtube_token_expiry', Date.now() + ((d.expires_in || 3600) * 1000));
+        clearPkceVerifier('youtube');
+        history.replaceState(null, '', window.location.pathname);
+        markConnected('youtube', d.access_token);
+      }
+    })
+    .catch(() => {});
+    return;
+  }
 
   if(token) {
     history.replaceState(null, '', window.location.pathname);
@@ -600,6 +695,7 @@ function emitOAuthCallback(platform, payload) {
 loadConfig().then(() => {
   restoreTwitchSession();
   restoreKickSession();
+  restoreYoutubeSession();
 });
 
 function restoreKickSession() {
@@ -645,6 +741,59 @@ function restoreTwitchSession() {
   .catch(() => markConnected('twitch', token));
 }
 
+function restoreYoutubeSession() {
+  const refreshToken = localStorage.getItem('youtube_refresh_token');
+  const accessToken  = localStorage.getItem('youtube_access_token');
+  const expiry       = parseInt(localStorage.getItem('youtube_token_expiry') || '0', 10);
+  if(!refreshToken) return;
+  if(accessToken && expiry > Date.now() + 300000) {
+    markConnected('youtube', accessToken);
+    return;
+  }
+  fetch('/youtube-refresh', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ refresh_token: refreshToken }),
+  })
+  .then(r => r.json())
+  .then(d => {
+    if(d.access_token) {
+      localStorage.setItem('youtube_access_token', d.access_token);
+      localStorage.setItem('youtube_token_expiry', Date.now() + ((d.expires_in || 3600) * 1000));
+      markConnected('youtube', d.access_token);
+    } else {
+      localStorage.removeItem('youtube_refresh_token');
+      localStorage.removeItem('youtube_access_token');
+      localStorage.removeItem('youtube_token_expiry');
+    }
+  })
+  .catch(() => {});
+}
+
+function scheduleYoutubeTokenRefresh() {
+  if(S.intervals.youtubeAuth) { clearTimeout(S.intervals.youtubeAuth); S.intervals.youtubeAuth = null; }
+  const refreshToken = localStorage.getItem('youtube_refresh_token');
+  const expiry = parseInt(localStorage.getItem('youtube_token_expiry') || '0', 10);
+  if(!refreshToken || !expiry) return;
+  const delay = Math.max(5000, expiry - Date.now() - (5 * 60 * 1000));
+  S.intervals.youtubeAuth = setTimeout(async () => {
+    try {
+      const r = await fetch('/youtube-refresh', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ refresh_token: refreshToken }),
+      });
+      const d = await r.json();
+      if(d.access_token) {
+        localStorage.setItem('youtube_access_token', d.access_token);
+        localStorage.setItem('youtube_token_expiry', Date.now() + ((d.expires_in || 3600) * 1000));
+        S.tokens.youtube = d.access_token;
+      }
+    } catch(_) {}
+    scheduleYoutubeTokenRefresh();
+  }, delay);
+}
+
 // Kick uses PKCE Authorization Code flow via the local server.
 // OAuth callback flow.
 function startOAuth(p) {
@@ -654,6 +803,7 @@ function startOAuth(p) {
     return;
   }
   if(p === 'kick') { startKickOAuth(); return; }
+  if(p === 'youtube') { startYoutubeOAuth(); return; }
 
   S.currentPlatform = p;
   const c = CFG[p];
@@ -718,6 +868,83 @@ function startOAuth(p) {
       if(!S.tokens[p]) {
         resetConnectBtn(p);
         showToast('Authorization cancelled');
+      }
+    }
+  }, 400);
+}
+
+async function startYoutubeOAuth() {
+  const btn = document.getElementById('btn-youtube');
+  btn.textContent = 'Connecting...';
+  btn.className = 'conn-btn pending';
+
+  let clientId = YOUTUBE_CLIENT_ID_PUB;
+  if(!clientId) {
+    try {
+      const r = await fetch('/config');
+      if(r.ok) {
+        const d = await r.json();
+        clientId = d.youtube?.client_id || '';
+        if(clientId) YOUTUBE_CLIENT_ID_PUB = clientId;
+      }
+    } catch(_) {}
+  }
+  if(!clientId) {
+    resetConnectBtn('youtube');
+    showToast('YouTube OAuth is not configured. Add youtube.client_id to config.json.');
+    return;
+  }
+
+  const { verifier, challenge } = await generatePKCE();
+  setPkceVerifier('youtube', verifier);
+  const redirectUri = encodeURIComponent(getRedirectUri());
+  const state = 'youtube';
+  const oauthUrl = `https://accounts.google.com/o/oauth2/v2/auth`
+    + `?client_id=${encodeURIComponent(clientId)}`
+    + `&redirect_uri=${redirectUri}`
+    + `&response_type=code`
+    + `&scope=${encodeURIComponent('https://www.googleapis.com/auth/youtube.force-ssl')}`
+    + `&access_type=offline`
+    + `&prompt=consent`
+    + `&code_challenge=${challenge}`
+    + `&code_challenge_method=S256`
+    + `&state=${state}`;
+
+  const width = 500, height = 700;
+  const left = Math.round(window.screenX + (window.outerWidth - width) / 2);
+  const top = Math.round(window.screenY + (window.outerHeight - height) / 2);
+  const popup = window.open(oauthUrl, 'youtube_oauth', `width=${width},height=${height},left=${left},top=${top},toolbar=no,menubar=no`);
+  if(!popup) {
+    showToast('Popup blocked — redirecting in current tab...');
+    setTimeout(() => { window.location.href = oauthUrl; }, 1000);
+    return;
+  }
+
+  function onMessage(e) {
+    if(e.origin !== window.location.origin) return;
+    if(!e.data || e.data.type !== 'oauth_callback' || e.data.platform !== 'youtube') return;
+    window.removeEventListener('message', onMessage);
+    clearInterval(closedPoll);
+    if(e.data.token) {
+      if(e.data.refresh_token) localStorage.setItem('youtube_refresh_token', e.data.refresh_token);
+      localStorage.setItem('youtube_access_token', e.data.token);
+      localStorage.setItem('youtube_token_expiry', Date.now() + ((e.data.expires_in || 3600) * 1000));
+      clearPkceVerifier('youtube');
+      markConnected('youtube', e.data.token);
+    } else {
+      resetConnectBtn('youtube');
+      showToast(`YouTube auth failed: ${(e.data.error || 'unknown').replace(/\+/g, ' ')}`);
+    }
+  }
+  window.addEventListener('message', onMessage);
+
+  const closedPoll = setInterval(() => {
+    if(popup.closed) {
+      clearInterval(closedPoll);
+      window.removeEventListener('message', onMessage);
+      if(!S.tokens.youtube) {
+        resetConnectBtn('youtube');
+        showToast('YouTube authorization cancelled');
       }
     }
   }, 400);
@@ -850,6 +1077,9 @@ function markConnected(p, token) {
     })
     .catch(() => {});
   }
+  if(p === 'youtube') {
+    scheduleYoutubeTokenRefresh();
+  }
   const btn = document.getElementById(`btn-${p}`);
   btn.textContent = 'Disconnect';
   btn.className = 'conn-btn discon';
@@ -897,6 +1127,19 @@ function fetchDisplayName(p, token) {
       if(name) { statusEl.textContent = `Connected as ${name}`; S.kickUserLogin = name; }
     })
     .catch(() => {});
+  } else if(p === 'youtube') {
+    fetch('https://www.googleapis.com/youtube/v3/channels?part=snippet&mine=true', {
+      headers: { 'Authorization': `Bearer ${token}` }
+    })
+    .then(r => r.ok ? r.json() : null)
+    .then(d => {
+      const name = d?.items?.[0]?.snippet?.title;
+      if(name) {
+        statusEl.textContent = `Connected as ${name}`;
+        S.youtubeUserName = name;
+      }
+    })
+    .catch(() => {});
   }
 }
 
@@ -923,6 +1166,14 @@ function disconnectPlatform(p) {
   }
   if(p === 'twitch')  { localStorage.removeItem('twitch_access_token');  S.twitchUserLogin  = null; S.twitchUserId = null; }
   if(p === 'kick')    { S.kickUserLogin = null; }
+  if(p === 'youtube') {
+    localStorage.removeItem('youtube_refresh_token');
+    localStorage.removeItem('youtube_access_token');
+    localStorage.removeItem('youtube_token_expiry');
+    if(S.intervals.youtube) { clearTimeout(S.intervals.youtube); S.intervals.youtube = null; }
+    if(S.intervals.youtubeAuth) { clearTimeout(S.intervals.youtubeAuth); S.intervals.youtubeAuth = null; }
+    S.youtubeUserName = null;
+  }
   document.getElementById(`row-${p}`).className = 'oauth-row';
   document.getElementById(`sd-${p}`).className = 'status-dot off';
   document.getElementById(`st-${p}`).textContent = 'Not connected';
@@ -943,7 +1194,7 @@ function dismiss() {
 function openOAuth() { document.getElementById('oauth-overlay').classList.remove('hidden'); }
 
 function refreshAccDots() {
-  ['twitch','kick'].forEach(p => {
+  ['twitch','kick','youtube'].forEach(p => {
     document.getElementById(`ad-${p}`).className = `acc-dot${S.auth[p]?' on-'+p:''}`;
   });
 }
@@ -1085,7 +1336,7 @@ function setTarget(t) {
 function joinCh(p) {
   const input = document.getElementById(`ci-${p}`);
   const raw = input.value.trim();
-  const ch = raw.toLowerCase();
+  const ch = p === 'youtube' ? raw : raw.toLowerCase();
   if(!ch){input.focus();return;}
   S.channels[p] = ch;
   document.getElementById(`cw-${p}`).classList.add(`act-${p}`);
@@ -1096,6 +1347,7 @@ function joinCh(p) {
   document.getElementById('empty-state')?.remove();
   if(p === 'twitch') connectTwitch(ch);
   else if(p === 'kick') connectKick(ch);
+  else if(p === 'youtube') connectYouTube(ch);
   refreshBanner();
   refreshTargets();
   showToast(`Watching ${ch} on ${CFG[p].name}`);
@@ -1108,6 +1360,13 @@ function leaveCh(p) {
   if(S.intervals[p]) { clearInterval(S.intervals[p]); S.intervals[p] = null; }
   if(p === 'twitch') { S.twitchBroadcasterId = null; S.twitchBroadcasterChannel = null; S.thirdPartyEmotes.twitch = {}; S.nativeEmotes.twitch = {}; S.twitchBadges = { global: {}, channel: {}, broadcasterId: null }; }
   if(p === 'kick')   { S.kickBroadcasterId   = null; S.kickBroadcasterChannel   = null; S.thirdPartyEmotes.kick   = {}; S.nativeEmotes.kick   = {}; }
+  if(p === 'youtube') {
+    if(S.intervals.youtube) { clearTimeout(S.intervals.youtube); S.intervals.youtube = null; }
+    S.youtubeLiveChatId = null;
+    S.youtubeVideoId = null;
+    S.youtubeNextPageToken = '';
+    S.youtubeSeenMessageIds = new Set();
+  }
   document.getElementById(`cw-${p}`).classList.remove(`act-${p}`);
   const btn = document.getElementById(`jb-${p}`);
   btn.textContent = 'Join';
@@ -1115,6 +1374,105 @@ function leaveCh(p) {
   btn.onclick = () => joinCh(p);
   addSys(`Left ${CFG[p].name} channel`);
   refreshTargets();
+}
+
+function parseYouTubeVideoId(input) {
+  const raw = String(input || '').trim();
+  if(!raw) return '';
+  if(/^[a-zA-Z0-9_-]{11}$/.test(raw)) return raw;
+  try {
+    const url = new URL(raw);
+    if(url.hostname.includes('youtu.be')) return (url.pathname || '').replace('/','').slice(0,11);
+    if(url.searchParams.get('v')) return url.searchParams.get('v').slice(0,11);
+    const parts = url.pathname.split('/').filter(Boolean);
+    const embedIdx = parts.findIndex(p => p === 'live' || p === 'embed' || p === 'shorts');
+    if(embedIdx !== -1 && parts[embedIdx + 1]) return parts[embedIdx + 1].slice(0,11);
+  } catch(_) {}
+  return raw.slice(0,11);
+}
+
+const YOUTUBE_MIN_POLL_INTERVAL_MS = 20000;
+const YOUTUBE_MAX_POLL_INTERVAL_MS = 120000;
+
+async function connectYouTube(videoInput) {
+  if(!S.tokens.youtube) {
+    addSys('YouTube: connect your account first.');
+    return;
+  }
+  const videoId = parseYouTubeVideoId(videoInput);
+  if(!videoId || videoId.length !== 11) {
+    addSys('YouTube: enter a valid live video URL or 11-character video ID.');
+    return;
+  }
+  S.youtubeVideoId = videoId;
+  S.youtubeNextPageToken = '';
+  S.youtubeSeenMessageIds = new Set();
+  addSys(`Connecting to YouTube live chat for video ${videoId}...`);
+
+  try {
+    const detailsRes = await fetch(`https://www.googleapis.com/youtube/v3/videos?part=snippet,liveStreamingDetails&id=${encodeURIComponent(videoId)}`, {
+      headers: { 'Authorization': `Bearer ${S.tokens.youtube}` }
+    });
+    const details = await detailsRes.json();
+    const item = details?.items?.[0];
+    const liveChatId = item?.liveStreamingDetails?.activeLiveChatId;
+    if(!liveChatId) {
+      addSys('YouTube: no active live chat found for that video (it may not be live).');
+      return;
+    }
+    S.youtubeLiveChatId = liveChatId;
+    const title = item?.snippet?.title || videoId;
+    addSys(`Connected to YouTube: ${title}`);
+    addSys('YouTube polling set to quota-safe mode (minimum 20s between polls for 10h sessions).');
+    pollYouTubeLiveChat();
+  } catch(e) {
+    addSys(`YouTube: could not load live chat (${e.message})`);
+  }
+}
+
+async function pollYouTubeLiveChat() {
+  if(!S.channels.youtube || !S.youtubeLiveChatId || !S.tokens.youtube) return;
+  const params = new URLSearchParams({
+    liveChatId: S.youtubeLiveChatId,
+    part: 'id,snippet,authorDetails',
+    maxResults: '200',
+  });
+  if(S.youtubeNextPageToken) params.set('pageToken', S.youtubeNextPageToken);
+
+  let nextDelay = YOUTUBE_MIN_POLL_INTERVAL_MS;
+  try {
+    const r = await fetch(`https://www.googleapis.com/youtube/v3/liveChat/messages?${params.toString()}`, {
+      headers: { 'Authorization': `Bearer ${S.tokens.youtube}` },
+    });
+    const d = await r.json();
+    if(!r.ok) throw new Error(d.error?.message || `HTTP ${r.status}`);
+    S.youtubeNextPageToken = d.nextPageToken || S.youtubeNextPageToken;
+    const items = d.items || [];
+    items.forEach(msg => {
+      if(!msg?.id || S.youtubeSeenMessageIds.has(msg.id)) return;
+      S.youtubeSeenMessageIds.add(msg.id);
+      if(S.youtubeSeenMessageIds.size > 1200) {
+        const first = S.youtubeSeenMessageIds.values().next().value;
+        S.youtubeSeenMessageIds.delete(first);
+      }
+      if(msg?.snippet?.type !== 'textMessageEvent') return;
+      const text = msg?.snippet?.textMessageDetails?.messageText || '';
+      if(!text) return;
+      const author = msg?.authorDetails?.displayName || 'YouTube';
+      const badge = msg?.authorDetails?.isChatModerator ? 'mod' : null;
+      addMsg('youtube', author, text, badge, null, null, '', { messageId: msg.id });
+    });
+    const apiInterval = Number(d.pollingIntervalMillis) || YOUTUBE_MIN_POLL_INTERVAL_MS;
+    nextDelay = Math.min(YOUTUBE_MAX_POLL_INTERVAL_MS, Math.max(YOUTUBE_MIN_POLL_INTERVAL_MS, apiInterval));
+  } catch(e) {
+    addSys(`YouTube polling error: ${e.message}`);
+    nextDelay = YOUTUBE_MAX_POLL_INTERVAL_MS;
+  }
+
+  if(S.channels.youtube && S.youtubeLiveChatId) {
+    if(S.intervals.youtube) clearTimeout(S.intervals.youtube);
+    S.intervals.youtube = setTimeout(pollYouTubeLiveChat, nextDelay);
+  }
 }
 
 function parseTwitchIrcTags(rawLine) {
@@ -2150,6 +2508,7 @@ function addMsg(p, author, text, badge, emoteMap, _unusedBadgeUrl, authorPrefixH
   const selfNames = [
     S.twitchUserLogin,
     S.kickUserLogin,
+    S.youtubeUserName,
   ].filter(Boolean).map(n => n.toLowerCase());
 
   if(selfNames.length > 0) {
@@ -2780,6 +3139,7 @@ function sendMsg() {
 async function sendToPlatform(p, text) {
   if(p === 'twitch') await sendTwitch(text);
   else if(p === 'kick') await sendKick(text);
+  else if(p === 'youtube') await sendYouTube(text);
 }
 
 async function sendTwitch(text) {
@@ -2872,6 +3232,38 @@ async function sendKick(text) {
     }
   } catch(e) {
     addSys(`Kick send failed: ${e.message}`);
+  }
+}
+
+async function sendYouTube(text) {
+  const token = S.tokens.youtube;
+  const liveChatId = S.youtubeLiveChatId;
+  if(!token) { addSys('YouTube: connect your account first'); return; }
+  if(!liveChatId) { addSys('YouTube: join a live video first'); return; }
+
+  try {
+    const res = await fetch('https://www.googleapis.com/youtube/v3/liveChat/messages?part=snippet', {
+      method: 'POST',
+      headers: {
+        'Authorization': `Bearer ${token}`,
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify({
+        snippet: {
+          liveChatId,
+          type: 'textMessageEvent',
+          textMessageDetails: { messageText: text }
+        }
+      })
+    });
+    const data = await res.json().catch(() => ({}));
+    if(!res.ok) {
+      addSys(`YouTube send error: ${data?.error?.message || data?.error || res.status}`);
+      return;
+    }
+    showToast('Sent to YouTube');
+  } catch(e) {
+    addSys(`YouTube send failed: ${e.message}`);
   }
 }
 

--- a/main.js
+++ b/main.js
@@ -57,6 +57,7 @@ function createWindow() {
     const isOAuth =
       url.includes('id.twitch.tv/oauth2') ||
       url.includes('accounts.google.com/o/oauth2') ||
+      url.includes('accounts.google.com/o/oauth2/v2/auth') ||
       url.includes('id.kick.com/oauth');
     if(isOAuth) {
       return {

--- a/server.js
+++ b/server.js
@@ -27,7 +27,9 @@ function start(CFG) {
   const PORT = CFG.port || 8080;
   const KICK_CLIENT_ID = CFG.kick?.client_id || '';
   const KICK_CLIENT_SECRET = CFG.kick?.client_secret || '';
+  const YOUTUBE_CLIENT_ID = CFG.youtube?.client_id || '';
   const HAS_KICK_OAUTH_CONFIG = !!(KICK_CLIENT_ID && KICK_CLIENT_SECRET);
+  const HAS_YOUTUBE_OAUTH_CONFIG = !!YOUTUBE_CLIENT_ID;
 
   const server = http.createServer(async (req, res) => {
     const pathname = new URL(req.url, `http://localhost:${PORT}`).pathname;
@@ -43,7 +45,9 @@ function start(CFG) {
       res.end(JSON.stringify({
         twitch:  { client_id: CFG.twitch?.client_id  || '' },
         kick:    { client_id: KICK_CLIENT_ID },
+        youtube: { client_id: YOUTUBE_CLIENT_ID },
         has_kick_oauth_config: HAS_KICK_OAUTH_CONFIG,
+        has_youtube_oauth_config: HAS_YOUTUBE_OAUTH_CONFIG,
       }));
       return;
     }
@@ -81,6 +85,87 @@ function start(CFG) {
           access_token:  data.access_token,
           refresh_token: data.refresh_token,
           expires_in:    data.expires_in,
+        }));
+      } catch(e) {
+        res.writeHead(500, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ error: e.message }));
+      }
+      return;
+    }
+
+    // ── /youtube-token — exchanges Google OAuth code for tokens (PKCE) ──────
+    if(pathname === '/youtube-token' && req.method === 'POST') {
+      if(!HAS_YOUTUBE_OAUTH_CONFIG) {
+        res.writeHead(503, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ error: 'YouTube OAuth not configured in config.json' }));
+        return;
+      }
+      try {
+        const { code, code_verifier, redirect_uri } = await readBody(req);
+        const params = new URLSearchParams({
+          grant_type: 'authorization_code',
+          client_id: YOUTUBE_CLIENT_ID,
+          code: String(code || ''),
+          code_verifier: String(code_verifier || ''),
+          redirect_uri: String(redirect_uri || `http://localhost:${PORT}/friendly-chat.html`)
+        });
+        const tokenRes = await fetch('https://oauth2.googleapis.com/token', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+          body: params.toString(),
+        });
+        const data = await tokenRes.json().catch(() => ({}));
+        if(!tokenRes.ok) {
+          res.writeHead(400, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify({ error: data.error_description || data.error || 'youtube token exchange failed' }));
+          return;
+        }
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({
+          access_token: data.access_token,
+          refresh_token: data.refresh_token,
+          expires_in: data.expires_in,
+          scope: data.scope,
+          token_type: data.token_type,
+        }));
+      } catch(e) {
+        res.writeHead(500, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ error: e.message }));
+      }
+      return;
+    }
+
+    // ── /youtube-refresh — refreshes YouTube access token ───────────────────
+    if(pathname === '/youtube-refresh' && req.method === 'POST') {
+      if(!HAS_YOUTUBE_OAUTH_CONFIG) {
+        res.writeHead(503, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ error: 'YouTube OAuth not configured in config.json' }));
+        return;
+      }
+      try {
+        const { refresh_token } = await readBody(req);
+        const params = new URLSearchParams({
+          grant_type: 'refresh_token',
+          client_id: YOUTUBE_CLIENT_ID,
+          refresh_token: String(refresh_token || ''),
+        });
+        const tokenRes = await fetch('https://oauth2.googleapis.com/token', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+          body: params.toString(),
+        });
+        const data = await tokenRes.json().catch(() => ({}));
+        if(!tokenRes.ok) {
+          res.writeHead(400, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify({ error: data.error_description || data.error || 'youtube refresh failed' }));
+          return;
+        }
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({
+          access_token: data.access_token,
+          expires_in: data.expires_in,
+          scope: data.scope,
+          token_type: data.token_type,
         }));
       } catch(e) {
         res.writeHead(500, { 'Content-Type': 'application/json' });


### PR DESCRIPTION
### Motivation
- Restore YouTube support as a first-class platform so users can view and participate in YouTube live chat alongside Twitch and Kick. 
- Use a user-supplied Google OAuth client ID to avoid embedding project credentials and to let users run under their own YouTube Data API quota. 
- Minimize risk of exhausting Google API quota during long sessions by making polling quota-aware and conservative.

### Description
- UI and state: added YouTube to the OAuth modal, join input, filter chips, send-target chips, account dots, styling, and expanded `ALL_PLATFORMS` and `S` state to include `youtube` in `friendly-chat.html`.
- OAuth/token flow: implemented PKCE-based Google OAuth flow in the frontend (`startYoutubeOAuth`, popup/callback handling, `restoreYoutubeSession`, `scheduleYoutubeTokenRefresh`) and server-side exchanges in `server.js` (`/youtube-token`, `/youtube-refresh`), and added `youtube.client_id` to `config.json` and `/config` output.
- Live chat: added logic to parse video URL/ID, resolve `activeLiveChatId` via `videos` endpoint, poll `liveChat/messages` with page tokens, dedupe messages, and display YouTube messages in the unified feed (`connectYouTube`, `pollYouTubeLiveChat`, message rendering and mention highlight support).
- Send messages: implemented sending via `liveChatMessages.insert` in the frontend (`sendYouTube`) and wired YouTube to the send-target path; added token persistence and background refresh scheduling to support long sessions.
- Quota safety: enforced a minimum poll interval of 20s (`YOUTUBE_MIN_POLL_INTERVAL_MS`) and bounded polling to 20s–120s (respecting API-provided `pollingIntervalMillis`) to keep ~1,800 polls over 10 hours by default, and documented setup/quotas in `README.md`.

### Testing
- Ran syntax checks: `node --check server.js` and `node --check main.js` successfully passed. 
- Extracted and type-checked embedded frontend script with `node --check /tmp/friendly-chat.js`, which succeeded. 
- No automated integration tests were available for OAuth/live API calls in this environment, so runtime behavior (OAuth exchanges, polling against Google APIs) should be verified live with a valid `youtube.client_id` and credentials.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e414567bf48321a857ef450fcff57a)