### PR TITLE
Add runtime OAuth config endpoint and client prompts for YouTube and Kick

### DIFF
--- a/friendly-chat.html
+++ b/friendly-chat.html
@@ -873,6 +873,67 @@ function startOAuth(p) {
   }, 400);
 }
 
+async function promptForRuntimeOAuthConfig(platform) {
+  if(platform === 'youtube') {
+    const clientId = (window.prompt('Enter your YouTube OAuth Client ID:', YOUTUBE_CLIENT_ID_PUB || '') || '').trim();
+    if(!clientId) {
+      showToast('YouTube setup cancelled');
+      return false;
+    }
+    try {
+      const res = await fetch('/oauth-config', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ platform: 'youtube', client_id: clientId }),
+      });
+      const data = await res.json().catch(() => ({}));
+      if(!res.ok) {
+        showToast(`YouTube config failed: ${data.error || 'unknown error'}`);
+        return false;
+      }
+      YOUTUBE_CLIENT_ID_PUB = clientId;
+      showToast('YouTube OAuth client configured for this app session');
+      return true;
+    } catch(e) {
+      showToast(`YouTube config failed: ${e.message}`);
+      return false;
+    }
+  }
+
+  if(platform === 'kick') {
+    const clientId = (window.prompt('Enter your Kick OAuth Client ID:', KICK_CLIENT_ID_PUB || '') || '').trim();
+    if(!clientId) {
+      showToast('Kick setup cancelled');
+      return false;
+    }
+    const clientSecret = (window.prompt('Enter your Kick OAuth Client Secret:') || '').trim();
+    if(!clientSecret) {
+      showToast('Kick setup cancelled');
+      return false;
+    }
+    try {
+      const res = await fetch('/oauth-config', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ platform: 'kick', client_id: clientId, client_secret: clientSecret }),
+      });
+      const data = await res.json().catch(() => ({}));
+      if(!res.ok) {
+        showToast(`Kick config failed: ${data.error || 'unknown error'}`);
+        return false;
+      }
+      KICK_CLIENT_ID_PUB = clientId;
+      showToast('Kick OAuth client configured for this app session');
+      return true;
+    } catch(e) {
+      showToast(`Kick config failed: ${e.message}`);
+      return false;
+    }
+  }
+
+  return false;
+}
+
 async function startYoutubeOAuth() {
   const btn = document.getElementById('btn-youtube');
   btn.textContent = 'Connecting...';
@@ -890,9 +951,12 @@ async function startYoutubeOAuth() {
     } catch(_) {}
   }
   if(!clientId) {
-    resetConnectBtn('youtube');
-    showToast('YouTube OAuth is not configured. Add youtube.client_id to config.json.');
-    return;
+    const configured = await promptForRuntimeOAuthConfig('youtube');
+    if(!configured) {
+      resetConnectBtn('youtube');
+      return;
+    }
+    clientId = YOUTUBE_CLIENT_ID_PUB;
   }
 
   const { verifier, challenge } = await generatePKCE();
@@ -986,9 +1050,12 @@ async function startKickOAuth() {
   }
 
   if(!clientId) {
-    resetConnectBtn('kick');
-    showToast('Kick OAuth is not configured. Add kick.client_id and kick.client_secret to config.json.');
-    return;
+    const configured = await promptForRuntimeOAuthConfig('kick');
+    if(!configured) {
+      resetConnectBtn('kick');
+      return;
+    }
+    clientId = KICK_CLIENT_ID_PUB;
   }
 
   // Generate PKCE challenge

--- a/server.js
+++ b/server.js
@@ -25,11 +25,20 @@ function readBody(req) {
 
 function start(CFG) {
   const PORT = CFG.port || 8080;
-  const KICK_CLIENT_ID = CFG.kick?.client_id || '';
-  const KICK_CLIENT_SECRET = CFG.kick?.client_secret || '';
-  const YOUTUBE_CLIENT_ID = CFG.youtube?.client_id || '';
-  const HAS_KICK_OAUTH_CONFIG = !!(KICK_CLIENT_ID && KICK_CLIENT_SECRET);
-  const HAS_YOUTUBE_OAUTH_CONFIG = !!YOUTUBE_CLIENT_ID;
+  let KICK_CLIENT_ID = '';
+  let KICK_CLIENT_SECRET = '';
+  let YOUTUBE_CLIENT_ID = '';
+  let HAS_KICK_OAUTH_CONFIG = false;
+  let HAS_YOUTUBE_OAUTH_CONFIG = false;
+
+  const applyOAuthConfigFromCfg = () => {
+    KICK_CLIENT_ID = CFG.kick?.client_id || '';
+    KICK_CLIENT_SECRET = CFG.kick?.client_secret || '';
+    YOUTUBE_CLIENT_ID = CFG.youtube?.client_id || '';
+    HAS_KICK_OAUTH_CONFIG = !!(KICK_CLIENT_ID && KICK_CLIENT_SECRET);
+    HAS_YOUTUBE_OAUTH_CONFIG = !!YOUTUBE_CLIENT_ID;
+  };
+  applyOAuthConfigFromCfg();
 
   const server = http.createServer(async (req, res) => {
     const pathname = new URL(req.url, `http://localhost:${PORT}`).pathname;
@@ -49,6 +58,49 @@ function start(CFG) {
         has_kick_oauth_config: HAS_KICK_OAUTH_CONFIG,
         has_youtube_oauth_config: HAS_YOUTUBE_OAUTH_CONFIG,
       }));
+      return;
+    }
+
+    // ── /oauth-config — runtime BYO OAuth client setup (local only) ─────────
+    if(pathname === '/oauth-config' && req.method === 'POST') {
+      try {
+        const body = await readBody(req);
+        const platform = String(body.platform || '').toLowerCase();
+        const clientId = String(body.client_id || '').trim();
+        const clientSecret = String(body.client_secret || '').trim();
+
+        if(platform === 'youtube') {
+          if(!clientId) {
+            res.writeHead(400, { 'Content-Type': 'application/json' });
+            res.end(JSON.stringify({ error: 'youtube client_id is required' }));
+            return;
+          }
+          CFG.youtube = { ...(CFG.youtube || {}), client_id: clientId };
+          applyOAuthConfigFromCfg();
+          res.writeHead(200, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify({ ok: true, has_youtube_oauth_config: HAS_YOUTUBE_OAUTH_CONFIG }));
+          return;
+        }
+
+        if(platform === 'kick') {
+          if(!clientId || !clientSecret) {
+            res.writeHead(400, { 'Content-Type': 'application/json' });
+            res.end(JSON.stringify({ error: 'kick client_id and client_secret are required' }));
+            return;
+          }
+          CFG.kick = { ...(CFG.kick || {}), client_id: clientId, client_secret: clientSecret };
+          applyOAuthConfigFromCfg();
+          res.writeHead(200, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify({ ok: true, has_kick_oauth_config: HAS_KICK_OAUTH_CONFIG }));
+          return;
+        }
+
+        res.writeHead(400, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ error: 'Unsupported platform. Use \"kick\" or \"youtube\".' }));
+      } catch(e) {
+        res.writeHead(500, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ error: e.message }));
+      }
       return;
     }
 


### PR DESCRIPTION
### Motivation

- Allow developers to provide OAuth client credentials at runtime for YouTube and Kick so the app can perform OAuth flows without requiring edits to `config.json` or a server restart.
- Improve local development and demo UX by prompting the user for missing client IDs/secrets and storing them for the current app session.

### Description

- Added a new server endpoint `POST /oauth-config` that accepts `{ platform, client_id, client_secret? }`, updates in-memory `CFG`, and refreshes `KICK_CLIENT_ID`, `KICK_CLIENT_SECRET`, and `YOUTUBE_CLIENT_ID` via `applyOAuthConfigFromCfg`.
- Made `/config` return runtime-updated public client IDs and flags (`has_kick_oauth_config`, `has_youtube_oauth_config`).
- Introduced `promptForRuntimeOAuthConfig` in `friendly-chat.html` to prompt users for YouTube `client_id` or Kick `client_id` and `client_secret`, and send them to `/oauth-config`.
- Updated `startYoutubeOAuth` and `startKickOAuth` to call the prompt when client credentials are missing and to proceed only if the runtime configuration succeeds.

### Testing

- No automated tests were added or run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e41af9062083219771b8f734986570)