### PR TITLE
Support runtime client secrets and YouTube API key; sanitize and expose OAuth config flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Friendly Chat now performs Kick token exchange locally, so you do **not** need t
 }
 ```
 
-If `kick.client_id` or `kick.client_secret` is missing, Kick sign-in will be disabled until they are provided.
+If either `kick.client_id` or `kick.client_secret` is missing (or left as placeholders), Kick sign-in will prompt you to provide both at runtime before connecting.
 
 ## YouTube OAuth setup (bring your own Google OAuth client)
 
@@ -82,13 +82,15 @@ Friendly Chat supports YouTube live chat by using **your own Google OAuth client
     "client_secret": "YOUR_KICK_CLIENT_SECRET"
   },
   "youtube": {
-    "client_id": "YOUR_GOOGLE_OAUTH_CLIENT_ID"
+    "client_id": "YOUR_GOOGLE_OAUTH_CLIENT_ID",
+    "client_secret": "YOUR_GOOGLE_OAUTH_CLIENT_SECRET",
+    "api_key": "YOUR_YOUTUBE_DATA_API_KEY"
   },
   "port": 8080
 }
 ```
 
-If `youtube.client_id` is missing, YouTube sign-in will be disabled until it is provided.
+If any of `youtube.client_id`, `youtube.client_secret`, or `youtube.api_key` are missing (or left as placeholders), YouTube sign-in will prompt you to provide them at runtime before connecting.
 
 ### YouTube quota behavior (10-hour session safety)
 

--- a/friendly-chat.html
+++ b/friendly-chat.html
@@ -367,7 +367,10 @@ let TWITCH_CLIENT_ID  = '';
 let KICK_CLIENT_ID_PUB = '';
 let YOUTUBE_CLIENT_ID_PUB = '';
 let HAS_KICK_OAUTH_CONFIG = false;
+let HAS_KICK_CLIENT_SECRET = false;
 let HAS_YOUTUBE_OAUTH_CONFIG = false;
+let HAS_YOUTUBE_CLIENT_SECRET = false;
+let HAS_YOUTUBE_API_KEY = false;
 
 async function loadConfig(retries = 5, delayMs = 800) {
   dbg('config', 'Loading /config', { retries, delayMs });
@@ -380,13 +383,19 @@ async function loadConfig(retries = 5, delayMs = 800) {
       KICK_CLIENT_ID_PUB = c.kick?.client_id    || '';
       YOUTUBE_CLIENT_ID_PUB = c.youtube?.client_id || '';
       HAS_KICK_OAUTH_CONFIG = !!c.has_kick_oauth_config;
+      HAS_KICK_CLIENT_SECRET = !!c.has_kick_client_secret;
       HAS_YOUTUBE_OAUTH_CONFIG = !!c.has_youtube_oauth_config;
+      HAS_YOUTUBE_CLIENT_SECRET = !!c.has_youtube_client_secret;
+      HAS_YOUTUBE_API_KEY = !!c.has_youtube_api_key;
       dbg('config', 'Loaded /config successfully', {
         hasKickClientId: !!KICK_CLIENT_ID_PUB,
         hasKickOAuthConfig: HAS_KICK_OAUTH_CONFIG,
+        hasKickClientSecret: HAS_KICK_CLIENT_SECRET,
         hasTwitchClientId: !!TWITCH_CLIENT_ID,
         hasYoutubeClientId: !!YOUTUBE_CLIENT_ID_PUB,
-        hasYoutubeOAuthConfig: HAS_YOUTUBE_OAUTH_CONFIG
+        hasYoutubeOAuthConfig: HAS_YOUTUBE_OAUTH_CONFIG,
+        hasYoutubeClientSecret: HAS_YOUTUBE_CLIENT_SECRET,
+        hasYoutubeApiKey: HAS_YOUTUBE_API_KEY
       });
       CFG.twitch.url = `https://id.twitch.tv/oauth2/authorize?client_id=${TWITCH_CLIENT_ID}&scope=chat%3Aread+chat%3Aedit+user%3Awrite%3Achat+moderator%3Amanage%3Abanned_users+moderator%3Amanage%3Achat_messages+moderator%3Aread%3Afollowers+user%3Aread%3Aemotes&response_type=token`;
       return;
@@ -897,11 +906,21 @@ async function promptForRuntimeOAuthConfig(platform) {
       showToast('YouTube setup cancelled');
       return false;
     }
+    const clientSecret = (window.prompt('Enter your YouTube OAuth Client Secret:') || '').trim();
+    if(!clientSecret) {
+      showToast('YouTube setup cancelled');
+      return false;
+    }
+    const apiKey = (window.prompt('Enter your YouTube API Key:') || '').trim();
+    if(!apiKey) {
+      showToast('YouTube setup cancelled');
+      return false;
+    }
     try {
       const res = await fetch('/oauth-config', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ platform: 'youtube', client_id: clientId }),
+        body: JSON.stringify({ platform: 'youtube', client_id: clientId, client_secret: clientSecret, api_key: apiKey }),
       });
       const data = await res.json().catch(() => ({}));
       if(!res.ok) {
@@ -910,6 +929,8 @@ async function promptForRuntimeOAuthConfig(platform) {
       }
       YOUTUBE_CLIENT_ID_PUB = clientId;
       HAS_YOUTUBE_OAUTH_CONFIG = true;
+      HAS_YOUTUBE_CLIENT_SECRET = true;
+      HAS_YOUTUBE_API_KEY = true;
       showToast('YouTube OAuth client configured for this app session');
       return true;
     } catch(e) {
@@ -942,6 +963,7 @@ async function promptForRuntimeOAuthConfig(platform) {
       }
       KICK_CLIENT_ID_PUB = clientId;
       HAS_KICK_OAUTH_CONFIG = true;
+      HAS_KICK_CLIENT_SECRET = true;
       showToast('Kick OAuth client configured for this app session');
       return true;
     } catch(e) {
@@ -966,11 +988,13 @@ async function startYoutubeOAuth() {
         const d = await r.json();
         clientId = d.youtube?.client_id || '';
         HAS_YOUTUBE_OAUTH_CONFIG = !!d.has_youtube_oauth_config;
+        HAS_YOUTUBE_CLIENT_SECRET = !!d.has_youtube_client_secret;
+        HAS_YOUTUBE_API_KEY = !!d.has_youtube_api_key;
         if(clientId) YOUTUBE_CLIENT_ID_PUB = clientId;
       }
     } catch(_) {}
   }
-  if(!clientId || !HAS_YOUTUBE_OAUTH_CONFIG) {
+  if(!clientId || !HAS_YOUTUBE_OAUTH_CONFIG || !HAS_YOUTUBE_CLIENT_SECRET || !HAS_YOUTUBE_API_KEY) {
     const configured = await promptForRuntimeOAuthConfig('youtube');
     if(!configured) {
       resetConnectBtn('youtube');
@@ -1065,12 +1089,13 @@ async function startKickOAuth() {
         const d = await r.json();
         clientId = d.kick?.client_id || '';
         HAS_KICK_OAUTH_CONFIG = !!d.has_kick_oauth_config;
+        HAS_KICK_CLIENT_SECRET = !!d.has_kick_client_secret;
         if(clientId) KICK_CLIENT_ID_PUB = clientId;
       }
     } catch(e) {}
   }
 
-  if(!clientId || !HAS_KICK_OAUTH_CONFIG) {
+  if(!clientId || !HAS_KICK_OAUTH_CONFIG || !HAS_KICK_CLIENT_SECRET) {
     const configured = await promptForRuntimeOAuthConfig('kick');
     if(!configured) {
       resetConnectBtn('kick');

--- a/server.js
+++ b/server.js
@@ -25,18 +25,31 @@ function readBody(req) {
 
 function start(CFG) {
   const PORT = CFG.port || 8080;
+  const sanitizeConfigValue = (value = '') => {
+    const raw = String(value || '').trim();
+    if(!raw) return '';
+    if(/^YOUR[_\s-]/i.test(raw)) return '';
+    if(/^REPLACE[_\s-]/i.test(raw)) return '';
+    if(/^CHANGE[_\s-]/i.test(raw)) return '';
+    if(/^<.*>$/.test(raw)) return '';
+    return raw;
+  };
   let KICK_CLIENT_ID = '';
   let KICK_CLIENT_SECRET = '';
   let YOUTUBE_CLIENT_ID = '';
+  let YOUTUBE_CLIENT_SECRET = '';
+  let YOUTUBE_API_KEY = '';
   let HAS_KICK_OAUTH_CONFIG = false;
   let HAS_YOUTUBE_OAUTH_CONFIG = false;
 
   const applyOAuthConfigFromCfg = () => {
-    KICK_CLIENT_ID = CFG.kick?.client_id || '';
-    KICK_CLIENT_SECRET = CFG.kick?.client_secret || '';
-    YOUTUBE_CLIENT_ID = CFG.youtube?.client_id || '';
+    KICK_CLIENT_ID = sanitizeConfigValue(CFG.kick?.client_id);
+    KICK_CLIENT_SECRET = sanitizeConfigValue(CFG.kick?.client_secret);
+    YOUTUBE_CLIENT_ID = sanitizeConfigValue(CFG.youtube?.client_id);
+    YOUTUBE_CLIENT_SECRET = sanitizeConfigValue(CFG.youtube?.client_secret);
+    YOUTUBE_API_KEY = sanitizeConfigValue(CFG.youtube?.api_key);
     HAS_KICK_OAUTH_CONFIG = !!(KICK_CLIENT_ID && KICK_CLIENT_SECRET);
-    HAS_YOUTUBE_OAUTH_CONFIG = !!YOUTUBE_CLIENT_ID;
+    HAS_YOUTUBE_OAUTH_CONFIG = !!(YOUTUBE_CLIENT_ID && YOUTUBE_CLIENT_SECRET && YOUTUBE_API_KEY);
   };
   applyOAuthConfigFromCfg();
 
@@ -56,7 +69,10 @@ function start(CFG) {
         kick:    { client_id: KICK_CLIENT_ID },
         youtube: { client_id: YOUTUBE_CLIENT_ID },
         has_kick_oauth_config: HAS_KICK_OAUTH_CONFIG,
+        has_kick_client_secret: !!KICK_CLIENT_SECRET,
         has_youtube_oauth_config: HAS_YOUTUBE_OAUTH_CONFIG,
+        has_youtube_client_secret: !!YOUTUBE_CLIENT_SECRET,
+        has_youtube_api_key: !!YOUTUBE_API_KEY,
       }));
       return;
     }
@@ -66,16 +82,17 @@ function start(CFG) {
       try {
         const body = await readBody(req);
         const platform = String(body.platform || '').toLowerCase();
-        const clientId = String(body.client_id || '').trim();
-        const clientSecret = String(body.client_secret || '').trim();
+        const clientId = sanitizeConfigValue(body.client_id);
+        const clientSecret = sanitizeConfigValue(body.client_secret);
+        const apiKey = sanitizeConfigValue(body.api_key);
 
         if(platform === 'youtube') {
-          if(!clientId) {
+          if(!clientId || !clientSecret || !apiKey) {
             res.writeHead(400, { 'Content-Type': 'application/json' });
-            res.end(JSON.stringify({ error: 'youtube client_id is required' }));
+            res.end(JSON.stringify({ error: 'youtube client_id, client_secret, and api_key are required' }));
             return;
           }
-          CFG.youtube = { ...(CFG.youtube || {}), client_id: clientId };
+          CFG.youtube = { ...(CFG.youtube || {}), client_id: clientId, client_secret: clientSecret, api_key: apiKey };
           applyOAuthConfigFromCfg();
           res.writeHead(200, { 'Content-Type': 'application/json' });
           res.end(JSON.stringify({ ok: true, has_youtube_oauth_config: HAS_YOUTUBE_OAUTH_CONFIG }));


### PR DESCRIPTION
### Motivation
- Ensure Kick and YouTube OAuth flows work when `client_secret` and YouTube `api_key` are required by allowing runtime configuration instead of silently disabling sign-in. 
- Prevent placeholder values (e.g. `YOUR_*`, `<...>`) from being treated as valid credentials by sanitizing config entries. 
- Surface precise config presence to the UI so the app can prompt for missing pieces at runtime. 

### Description
- Add `sanitizeConfigValue` in `server.js` to normalize and reject placeholder/empty config values and wire sanitized values into `applyOAuthConfigFromCfg`. 
- Extend server `/config` response to include `has_kick_client_secret`, `has_youtube_client_secret`, and `has_youtube_api_key` flags and update `/oauth-config` to accept and validate `client_secret` and `api_key` for `youtube` and `client_secret` for `kick`. 
- Update `friendly-chat.html` to track the new flags (`HAS_KICK_CLIENT_SECRET`, `HAS_YOUTUBE_CLIENT_SECRET`, `HAS_YOUTUBE_API_KEY`), read them from `/config`, and prompt for the missing `client_secret` and `api_key` at runtime via `promptForRuntimeOAuthConfig` when starting OAuth. 
- Update `README.md` to document the additional YouTube parameters (`client_secret`, `api_key`) and clarify runtime prompts for missing Kick/YouTube credentials. 

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e42d85891c8321ac2a7c8c0e645582)