### PR TITLE
Move Kick OAuth credentials to Cloudflare Worker proxy

### DIFF
--- a/cloudflare-worker.js
+++ b/cloudflare-worker.js
@@ -1,0 +1,108 @@
+// Friendly Chat - Cloudflare Worker
+// Keeps your Kick Client ID and Client Secret out of the desktop app.
+//
+// Deploy:
+//   npm install -g wrangler
+//   wrangler login
+//   wrangler secret put KICK_CLIENT_ID      (paste your Client ID when prompted)
+//   wrangler secret put KICK_CLIENT_SECRET  (paste your Client Secret when prompted)
+//   wrangler deploy
+//
+// Then paste the deployed Worker URL into config.json as kick.proxy_url.
+
+export default {
+  async fetch(request, env) {
+    const url    = new URL(request.url);
+    const origin = request.headers.get('Origin') || '*';
+
+    if (request.method === 'OPTIONS') {
+      return new Response(null, { status: 204, headers: cors(origin) });
+    }
+
+    if (url.pathname === '/health' && request.method === 'GET') {
+      return json({ ok: true, service: 'friendly-chat-kick-proxy' }, 200, origin);
+    }
+
+    // Returns the Kick Client ID (public — safe to expose)
+    if (url.pathname === '/kick-config' && request.method === 'GET') {
+      return json({ client_id: env.KICK_CLIENT_ID || '' }, 200, origin);
+    }
+
+    // Exchanges a PKCE auth code for access + refresh tokens
+    if (url.pathname === '/kick-token' && request.method === 'POST') {
+      try {
+        const { code, code_verifier, redirect_uri } = await request.json();
+        const params = new URLSearchParams({
+          grant_type:    'authorization_code',
+          client_id:     env.KICK_CLIENT_ID,
+          client_secret: env.KICK_CLIENT_SECRET,
+          redirect_uri,
+          code_verifier,
+          code,
+        });
+        const kickRes = await fetch('https://id.kick.com/oauth/token', {
+          method:  'POST',
+          headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+          body:    params.toString(),
+        });
+        const data = await kickRes.json();
+        if (!kickRes.ok) {
+          return json({ error: data.error || 'token exchange failed' }, 400, origin);
+        }
+        return json({
+          access_token:  data.access_token,
+          refresh_token: data.refresh_token,
+          expires_in:    data.expires_in,
+        }, 200, origin);
+      } catch (e) {
+        return json({ error: e.message }, 500, origin);
+      }
+    }
+
+    // Silently refreshes an expired Kick access token
+    if (url.pathname === '/kick-refresh' && request.method === 'POST') {
+      try {
+        const { refresh_token } = await request.json();
+        const params = new URLSearchParams({
+          grant_type:    'refresh_token',
+          client_id:     env.KICK_CLIENT_ID,
+          client_secret: env.KICK_CLIENT_SECRET,
+          refresh_token,
+        });
+        const kickRes = await fetch('https://id.kick.com/oauth/token', {
+          method:  'POST',
+          headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+          body:    params.toString(),
+        });
+        const data = await kickRes.json();
+        if (!kickRes.ok) {
+          return json({ error: data.error || 'refresh failed' }, 400, origin);
+        }
+        return json({
+          access_token:  data.access_token,
+          refresh_token: data.refresh_token,
+          expires_in:    data.expires_in,
+        }, 200, origin);
+      } catch (e) {
+        return json({ error: e.message }, 500, origin);
+      }
+    }
+
+    return json({ error: 'Not found' }, 404, origin);
+  },
+};
+
+function cors(origin) {
+  return {
+    'Access-Control-Allow-Origin':  origin,
+    'Access-Control-Allow-Methods': 'GET, POST, OPTIONS',
+    'Access-Control-Allow-Headers': 'Content-Type',
+  };
+}
+
+function json(data, status, origin) {
+  return new Response(JSON.stringify(data), {
+    status,
+    headers: { 'Content-Type': 'application/json', ...cors(origin) },
+  });
+}

--- a/config.json
+++ b/config.json
@@ -1,5 +1,5 @@
 {
   "twitch":  { "client_id": "6a1bqli3xxei93r1zu6msidt5xf4kj" },
-  "kick":    { "client_id": "01KM9M6876PX3CJ83FHPD1J3C2", "client_secret": "0b33d1a02a99bf087747e07f6ff0a33cc92f64f225c6274e29934949c97cbd76" },
+  "kick":    { "proxy_url": "" },
   "port": 8080
 }

--- a/server.js
+++ b/server.js
@@ -1,6 +1,6 @@
 // Friendly Chat - Local Server
-// Kick OAuth token exchange and refresh are handled locally using credentials
-// stored in config.json (kick.client_id and kick.client_secret).
+// Kick OAuth token exchange and refresh are forwarded to the Cloudflare Worker
+// whose URL is stored in config.json as kick.proxy_url.
 
 const http = require('http');
 const fs   = require('fs');
@@ -32,10 +32,18 @@ function readBody(req) {
 }
 
 function start(CFG) {
-  const PORT             = CFG.port || 8080;
-  const KICK_CLIENT_ID   = CFG.kick?.client_id     || '';
-  const KICK_CLIENT_SECRET = CFG.kick?.client_secret || '';
-  const HAS_KICK         = !!(KICK_CLIENT_ID && KICK_CLIENT_SECRET);
+  const PORT      = CFG.port || 8080;
+  const PROXY_URL = (CFG.kick?.proxy_url || '').replace(/\/$/, '');
+  const HAS_KICK  = !!PROXY_URL;
+
+  // Fetch and cache the Kick public client_id from the Cloudflare Worker
+  let kickClientId = '';
+  if (PROXY_URL) {
+    fetch(`${PROXY_URL}/kick-config`)
+      .then(r => r.ok ? r.json() : null)
+      .then(d => { if (d?.client_id) kickClientId = d.client_id; })
+      .catch(e => console.warn('  [proxy] Could not reach Kick proxy:', e.message));
+  }
 
   const staticCache = new Map();
 
@@ -51,47 +59,34 @@ function start(CFG) {
     if(pathname === '/config' && req.method === 'GET') {
       res.writeHead(200, { 'Content-Type': 'application/json' });
       res.end(JSON.stringify({
-        twitch: { client_id: CFG.twitch?.client_id || '' },
-        kick:   { client_id: KICK_CLIENT_ID },
+        twitch:   { client_id: CFG.twitch?.client_id || '' },
+        kick:     { client_id: kickClientId },
         has_kick: HAS_KICK,
       }));
       return;
     }
 
-    // ── /kick-token — exchange PKCE auth code for tokens ────────────────────
+    // ── /kick-token — forward PKCE code exchange to the Cloudflare Worker ───
     if(pathname === '/kick-token' && req.method === 'POST') {
       if(!HAS_KICK) {
         res.writeHead(503, { 'Content-Type': 'application/json' });
-        res.end(JSON.stringify({ error: 'Kick credentials not configured in config.json' }));
+        res.end(JSON.stringify({ error: 'kick.proxy_url not set in config.json' }));
         return;
       }
       try {
         const { code, code_verifier } = await readBody(req);
-        const params = new URLSearchParams({
-          grant_type:    'authorization_code',
-          client_id:     KICK_CLIENT_ID,
-          client_secret: KICK_CLIENT_SECRET,
-          redirect_uri:  `http://localhost:${PORT}/friendly-chat.html`,
-          code_verifier,
-          code,
-        });
-        const kickRes = await fetch('https://id.kick.com/oauth/token', {
+        const proxyRes = await fetch(`${PROXY_URL}/kick-token`, {
           method:  'POST',
-          headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-          body:    params.toString(),
+          headers: { 'Content-Type': 'application/json' },
+          body:    JSON.stringify({
+            code,
+            code_verifier,
+            redirect_uri: `http://localhost:${PORT}/friendly-chat.html`,
+          }),
         });
-        const data = await kickRes.json();
-        if(!kickRes.ok) {
-          res.writeHead(400, { 'Content-Type': 'application/json' });
-          res.end(JSON.stringify({ error: data.error || 'token exchange failed' }));
-          return;
-        }
-        res.writeHead(200, { 'Content-Type': 'application/json' });
-        res.end(JSON.stringify({
-          access_token:  data.access_token,
-          refresh_token: data.refresh_token,
-          expires_in:    data.expires_in,
-        }));
+        const data = await proxyRes.json();
+        res.writeHead(proxyRes.status, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify(data));
       } catch(e) {
         res.writeHead(500, { 'Content-Type': 'application/json' });
         res.end(JSON.stringify({ error: e.message }));
@@ -99,38 +94,23 @@ function start(CFG) {
       return;
     }
 
-    // ── /kick-refresh — refresh an expired Kick access token ─────────────────
+    // ── /kick-refresh — forward token refresh to the Cloudflare Worker ───────
     if(pathname === '/kick-refresh' && req.method === 'POST') {
       if(!HAS_KICK) {
         res.writeHead(503, { 'Content-Type': 'application/json' });
-        res.end(JSON.stringify({ error: 'Kick credentials not configured in config.json' }));
+        res.end(JSON.stringify({ error: 'kick.proxy_url not set in config.json' }));
         return;
       }
       try {
         const { refresh_token } = await readBody(req);
-        const params = new URLSearchParams({
-          grant_type:    'refresh_token',
-          client_id:     KICK_CLIENT_ID,
-          client_secret: KICK_CLIENT_SECRET,
-          refresh_token,
-        });
-        const kickRes = await fetch('https://id.kick.com/oauth/token', {
+        const proxyRes = await fetch(`${PROXY_URL}/kick-refresh`, {
           method:  'POST',
-          headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-          body:    params.toString(),
+          headers: { 'Content-Type': 'application/json' },
+          body:    JSON.stringify({ refresh_token }),
         });
-        const data = await kickRes.json();
-        if(!kickRes.ok) {
-          res.writeHead(400, { 'Content-Type': 'application/json' });
-          res.end(JSON.stringify({ error: data.error || 'refresh failed' }));
-          return;
-        }
-        res.writeHead(200, { 'Content-Type': 'application/json' });
-        res.end(JSON.stringify({
-          access_token:  data.access_token,
-          refresh_token: data.refresh_token,
-          expires_in:    data.expires_in,
-        }));
+        const data = await proxyRes.json();
+        res.writeHead(proxyRes.status, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify(data));
       } catch(e) {
         res.writeHead(500, { 'Content-Type': 'application/json' });
         res.end(JSON.stringify({ error: e.message }));
@@ -251,7 +231,7 @@ function start(CFG) {
 
   server.listen(PORT, () => {
     console.log(`\n  Friendly Chat running on http://localhost:${PORT}\n`);
-    if(!HAS_KICK) console.log('  ⚠  Kick credentials not set in config.json — Kick OAuth will not work\n');
+    if(!HAS_KICK) console.log('  ⚠  kick.proxy_url not set in config.json — Kick OAuth will not work\n');
   });
 
   return server;

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,0 +1,7 @@
+name            = "friendly-chat-kick-proxy"
+main            = "cloudflare-worker.js"
+compatibility_date = "2024-09-23"
+
+# Secrets are NOT stored here — set them with:
+#   wrangler secret put KICK_CLIENT_ID
+#   wrangler secret put KICK_CLIENT_SECRET


### PR DESCRIPTION
## Summary
Refactors the Kick OAuth implementation to use a Cloudflare Worker as a secure proxy for handling sensitive credentials, removing the need to store `client_secret` in the desktop application's config file.

## Key Changes
- **New Cloudflare Worker** (`cloudflare-worker.js`): Implements a proxy service that handles Kick OAuth token exchange and refresh operations using environment secrets
  - `/kick-config` endpoint: Returns the public `client_id`
  - `/kick-token` endpoint: Exchanges PKCE authorization codes for access/refresh tokens
  - `/kick-refresh` endpoint: Refreshes expired access tokens
  - Includes CORS support and health check endpoint
  
- **Updated local server** (`server.js`): Refactored to forward OAuth requests to the Cloudflare Worker instead of handling them directly
  - Removes direct Kick credential handling (`client_id` and `client_secret`)
  - Fetches and caches the public `client_id` from the proxy on startup
  - Forwards token exchange and refresh requests to the proxy endpoints
  - Updated error messages to reference `kick.proxy_url` configuration
  
- **Configuration changes** (`config.json`): 
  - Replaces `client_id` and `client_secret` fields with `proxy_url`
  - Credentials are now managed only in the Cloudflare Worker environment
  
- **Wrangler configuration** (`wrangler.toml`): Added deployment configuration for the Cloudflare Worker with instructions for setting secrets

## Implementation Details
- The local server fetches the public `client_id` from the proxy on startup and caches it for the `/config` endpoint
- All sensitive credential handling is isolated to the Cloudflare Worker, which uses environment secrets
- The proxy maintains the same OAuth flow semantics while adding an extra layer of security
- Deployment instructions are included in the worker file comments

https://claude.ai/code/session_01PhiYfbvxaXnMBLQofodsdD