### PR TITLE
Fix race condition: fetch kick client_id on-demand in /config

### DIFF
--- a/friendly-chat.html
+++ b/friendly-chat.html
@@ -761,7 +761,7 @@ async function startKickOAuth() {
 
   if(!clientId) {
     resetConnectBtn('kick');
-    showToast('Kick: client_id not set — add your Kick Client ID and Client Secret to config.json');
+    showToast('Kick: could not reach proxy — check kick.proxy_url in config.json');
     return;
   }
 

--- a/server.js
+++ b/server.js
@@ -57,6 +57,12 @@ function start(CFG) {
 
     // ── /config — public credentials only ───────────────────────────────────
     if(pathname === '/config' && req.method === 'GET') {
+      if(PROXY_URL && !kickClientId) {
+        try {
+          const r = await fetch(`${PROXY_URL}/kick-config`);
+          if(r.ok) { const d = await r.json(); if(d?.client_id) kickClientId = d.client_id; }
+        } catch(e) {}
+      }
       res.writeHead(200, { 'Content-Type': 'application/json' });
       res.end(JSON.stringify({
         twitch:   { client_id: CFG.twitch?.client_id || '' },


### PR DESCRIPTION
The background fetch of KICK_CLIENT_ID from the CF Worker could lose the race against the frontend's loadConfig() call, leaving client_id empty. Now /config fetches it inline if the cache is still cold.

Also update the stale error toast to point at proxy_url instead of config.json secrets.

https://claude.ai/code/session_01PhiYfbvxaXnMBLQofodsdD