### PR TITLE
Add secret validation and improve deployment documentation

### DIFF
--- a/cloudflare-worker.js
+++ b/cloudflare-worker.js
@@ -30,6 +30,9 @@ export default {
 
     // Exchanges a PKCE auth code for access + refresh tokens
     if (url.pathname === '/kick-token' && request.method === 'POST') {
+      if (!env.KICK_CLIENT_ID || !env.KICK_CLIENT_SECRET) {
+        return json({ error: 'Worker secrets not configured — run: wrangler secret put KICK_CLIENT_ID && wrangler secret put KICK_CLIENT_SECRET' }, 500, origin);
+      }
       try {
         const { code, code_verifier, redirect_uri } = await request.json();
         const params = new URLSearchParams({
@@ -61,6 +64,9 @@ export default {
 
     // Silently refreshes an expired Kick access token
     if (url.pathname === '/kick-refresh' && request.method === 'POST') {
+      if (!env.KICK_CLIENT_ID || !env.KICK_CLIENT_SECRET) {
+        return json({ error: 'Worker secrets not configured — run: wrangler secret put KICK_CLIENT_ID && wrangler secret put KICK_CLIENT_SECRET' }, 500, origin);
+      }
       try {
         const { refresh_token } = await request.json();
         const params = new URLSearchParams({

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,7 +1,11 @@
-name            = "friendly-chat-kick-proxy"
-main            = "cloudflare-worker.js"
+name               = "friendly-chat-kick-proxy"
+main               = "cloudflare-worker.js"
 compatibility_date = "2024-09-23"
+workers_dev        = true
 
 # Secrets are NOT stored here — set them with:
 #   wrangler secret put KICK_CLIENT_ID
 #   wrangler secret put KICK_CLIENT_SECRET
+#
+# Then deploy with:
+#   wrangler deploy


### PR DESCRIPTION
## Summary
This PR adds validation for required Kick API secrets and improves the deployment documentation in the Cloudflare Worker configuration.

## Key Changes
- **Secret Validation**: Added checks in both `/kick-token` and `/kick-refresh` endpoints to verify that `KICK_CLIENT_ID` and `KICK_CLIENT_SECRET` environment variables are configured before attempting to use them. Returns a helpful error message with setup instructions if secrets are missing.
- **Configuration Updates**: 
  - Enabled `workers_dev` in `wrangler.toml` for local development
  - Improved code formatting/alignment in `wrangler.toml`
  - Added deployment instructions in comments for better developer experience
- **Error Handling**: Provides clear, actionable error messages guiding users to configure secrets via `wrangler secret put` commands

## Implementation Details
The validation checks are placed at the entry point of each endpoint that requires the secrets, ensuring early failure with helpful guidance rather than cryptic errors downstream. The error response uses the existing `json()` helper with a 500 status code and includes the exact commands needed to configure the secrets.

https://claude.ai/code/session_01YM34arzNiXxPxtqja7HUKP