### PR TITLE
Fix Linux taskbar icon loading by using Electron nativeImage

### DIFF
--- a/main.js
+++ b/main.js
@@ -1,6 +1,6 @@
 // Friendly Chat - Electron Main Process
 
-const { app, BrowserWindow, shell, ipcMain } = require('electron');
+const { app, BrowserWindow, shell, ipcMain, nativeImage } = require('electron');
 const path = require('path');
 const fs   = require('fs');
 
@@ -39,11 +39,30 @@ function fetchKickEmotesViaWindow(channel) {
 // ── Window ────────────────────────────────────────────────────────────────────
 let mainWindow;
 
+function getLinuxAppIcon() {
+  if(process.platform !== 'linux') return undefined;
+
+  // Prefer resource path in packaged builds so the icon can be read by the OS.
+  const candidates = [
+    path.join(process.resourcesPath || '', 'icon.png'),
+    path.join(__dirname, 'icon.png'),
+  ];
+
+  for(const iconPath of candidates) {
+    if(iconPath && fs.existsSync(iconPath)) {
+      const image = nativeImage.createFromPath(iconPath);
+      if(!image.isEmpty()) return image;
+    }
+  }
+
+  return undefined;
+}
+
 function createWindow() {
   mainWindow = new BrowserWindow({
     width: 1280, height: 800, minWidth: 520, minHeight: 600,
     title: 'Friendly Chat',
-    icon: process.platform === 'linux' ? path.join(__dirname, 'icon.png') : undefined,
+    icon: getLinuxAppIcon(),
     webPreferences: {
       nodeIntegration: false,
       contextIsolation: true,


### PR DESCRIPTION
### Motivation
- Linux desktop environments sometimes ignore a raw icon path (especially when inside `app.asar`), causing the taskbar/dock icon to not appear at runtime.
- Windows and macOS icon settings were working and should remain unchanged, so the fix must be Linux-specific and safe in dev and packaged builds.

### Description
- Import `nativeImage` from `electron` and add a new `getLinuxAppIcon()` helper that returns a `nativeImage` or `undefined` when not available.
- `getLinuxAppIcon()` checks `process.resourcesPath/icon.png` first and falls back to `__dirname/icon.png`, uses `fs.existsSync()` and `nativeImage.createFromPath()` and validates with `image.isEmpty()` before returning.
- Replace the previous `icon: process.platform === 'linux' ? path.join(__dirname, 'icon.png') : undefined` with `icon: getLinuxAppIcon()` in the `BrowserWindow` options.

### Testing
- Ran a small Python check that read `icon.png` and confirmed it is a valid PNG (`512x512`) which completed successfully.
- Ran `node --check main.js` to validate the modified file and it passed without syntax errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f917ed87c483218160dd24161b1de1)